### PR TITLE
Fix for items not refunded during jump_pause_nosilence check

### DIFF
--- a/game/dota_addons/fateanother/scripts/vscripts/items.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/items.lua
@@ -528,7 +528,7 @@ function BScroll(keys)
 	local caster = keys.caster
 	local ability = keys.ability
 	if caster:HasModifier("jump_pause_nosilence") then
-		RefundItem(caster, ability, "item_b_scroll")
+		RefundItem(caster, ability)
 		return
 	end
 	ability:ApplyDataDrivenModifier(caster, caster, "modifier_b_scroll", {})

--- a/game/dota_addons/fateanother/scripts/vscripts/items.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/items.lua
@@ -1,5 +1,5 @@
 cdummy = nil
-itemKV = LoadKeyValues("scripts/npc/npc_items_custom.txt") 
+itemKV = LoadKeyValues("scripts/npc/npc_items_custom.txt")
 
 
 function ParseCombinationKV()
@@ -28,7 +28,7 @@ end
 
 
 function OnManaEssenceAcquired(keys)
-end 
+end
 
 function OnBaseEntered(trigger)
 	local hero = trigger.activator
@@ -143,7 +143,7 @@ function TransferItem(keys)
 		local hero_item = hero:GetItemInSlot(i)
 		for i=0, 5 do
 			if hero_item == nil then
-				hero:AddItem(stash_item) 
+				hero:AddItem(stash_item)
 				caster:RemoveItem(stash_item)
 				return
 			end
@@ -155,7 +155,7 @@ function TransferItem(keys)
 		stash_item:RemoveSelf()
 		--Timers:CreateTimer( 0.033, function()
 
-		hero:AddItem(newItem) 
+		hero:AddItem(newItem)
 		CheckItemCombination(hero)
 	else
 		SendErrorMessage(hero:GetPlayerOwnerID(), "#No_Items_Found")
@@ -163,11 +163,28 @@ function TransferItem(keys)
 
 end
 
+function RefundItem(caster, item)
+	local charges = item:GetCurrentCharges()
+	if charges == 0 then
+		local itemName = item:GetAbilityName()
+		item = CreateItem(itemName, caster, nil)
+		item:SetCurrentCharges(1)
+		caster:AddItem(item)
+	else
+		item:SetCurrentCharges(charges + 1)
+	end
+	item:EndCooldown()
+end
+
 function PotInstantHeal(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	caster:Heal(500, caster)
-	caster:GiveMana(300) 
+	caster:GiveMana(300)
 
 	local healFx = ParticleManager:CreateParticle("particles/units/heroes/hero_omniknight/omniknight_purification_g.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
 	ParticleManager:SetParticleControl(healFx, 1, caster:GetAbsOrigin()) -- target effect location
@@ -180,36 +197,36 @@ end
 
 function TPScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		caster:Stop()
+		return
+	end
 	local targetPoint = keys.target_points[1]
 	--print(caster:GetAbsOrigin().y .. " and " .. caster:GetAbsOrigin().x)
-	if caster:GetAbsOrigin().y < -2000 or targetPoint.y < -2000 then 
+	if caster:GetAbsOrigin().y < -2000 or targetPoint.y < -2000 then
 		SendErrorMessage(caster:GetPlayerOwnerID(), "#Invalid_Location")
-		local newTP = CreateItem("item_teleport_scroll" , caster, nil)
-		caster:AddItem(newTP)
-		newTP:EndCooldown()
+		RefundItem(caster, ability)
 		caster:Stop()
-		--caster:AddItem(CreateItem("item_teleport_scroll" , caster, nil))		
 		return
 	end
 
 	caster.TPLoc = nil
-	local targets = FindUnitsInRadius(caster:GetTeam(), targetPoint, nil, 10000, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_OTHER, 0, FIND_CLOSEST, false) 
+	local targets = FindUnitsInRadius(caster:GetTeam(), targetPoint, nil, 10000, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_OTHER, 0, FIND_CLOSEST, false)
 	if targets[1] == nil or targets[1]:GetAbsOrigin().y < -2000 then
 		SendErrorMessage(caster:GetPlayerOwnerID(), "#Invalid_Location")
-		local newTP = CreateItem("item_teleport_scroll" , caster, nil)
-		caster:AddItem(newTP)
-		newTP:EndCooldown()
+		RefundItem(caster, ability)
 		caster:Stop()
 		return
-	else 
+	else
 		caster.TPLoc = targets[1]:GetAbsOrigin()
 		local pfx = ParticleManager:CreateParticle( "particles/units/heroes/hero_wisp/wisp_relocate_teleport.vpcf", PATTACH_CUSTOMORIGIN, nil )
-		ParticleManager:SetParticleControl(pfx, 0, caster:GetAbsOrigin()) 
+		ParticleManager:SetParticleControl(pfx, 0, caster:GetAbsOrigin())
 
 
 		local pfx2 = ParticleManager:CreateParticle( "particles/units/heroes/hero_wisp/wisp_relocate_teleport.vpcf", PATTACH_CUSTOMORIGIN, nil )
-		ParticleManager:SetParticleControl(pfx2, 0, caster.TPLoc) 
+		ParticleManager:SetParticleControl(pfx2, 0, caster.TPLoc)
 
 		caster:EmitSound("Hero_Wisp.Relocate")
 		EmitSoundOnLocationWithCaster(caster.TPLoc, "Hero_Wisp.Relocate", targets[1])
@@ -225,7 +242,11 @@ end
 
 function TPSuccess(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	caster:EmitSound("Hero_Wisp.Return")
 	caster:SetAbsOrigin(caster.TPLoc)
 	FindClearSpaceForUnit(caster, caster:GetAbsOrigin(), true)
@@ -233,9 +254,13 @@ end
 
 function MassTPSuccess(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local targets = FindUnitsInRadius(caster:GetTeam(), caster:GetAbsOrigin(), nil, 1000
-            , DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_HERO, 0, FIND_ANY_ORDER, false)	
+            , DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_HERO, 0, FIND_ANY_ORDER, false)
 	if caster.TPLoc == nil then
 		FireGameEvent( 'custom_error_show', { player_ID = caster:GetPlayerOwnerID(), _error = "Must Have Ward Nearby Targeted Location" } )
 		caster:AddItem(CreateItem("item_teleport_scroll" , caster, nil))
@@ -253,11 +278,15 @@ end
 
 function WardFam(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local targetPoint = keys.target_points[1]
 	caster.ward = CreateUnitByName("ward_familiar", targetPoint, true, caster, caster, caster:GetTeamNumber())
-	caster.ward:AddNewModifier(caster, caster, "modifier_invisible", {}) 
-	caster.ward:AddNewModifier(caster, caster, "modifier_item_ward_true_sight", {true_sight_range = keys.Radius, duration = keys.Duration}) 
+	caster.ward:AddNewModifier(caster, caster, "modifier_invisible", {})
+	caster.ward:AddNewModifier(caster, caster, "modifier_item_ward_true_sight", {true_sight_range = keys.Radius, duration = keys.Duration})
     caster.ward:AddNewModifier(caster, caster, "modifier_kill", {duration = keys.Duration})
 
     EmitSoundOnLocationForAllies(targetPoint,"DOTA_Item.ObserverWard.Activate",caster)
@@ -270,11 +299,15 @@ end
 
 function ScoutFam(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local pid = caster:GetPlayerID()
 	local scout = CreateUnitByName("scout_familiar", caster:GetAbsOrigin(), true, caster, caster, caster:GetTeamNumber())
 	scout:SetControllableByPlayer(pid, true)
-	keys.ability:ApplyDataDrivenModifier(caster, scout, "modifier_banished", {}) 
+	keys.ability:ApplyDataDrivenModifier(caster, scout, "modifier_banished", {})
 	LevelAllAbility(scout)
    	scout:AddNewModifier(caster, nil, "modifier_kill", {duration = 40})
 end
@@ -283,14 +316,14 @@ function BecomeWard(keys)
 	local caster = keys.caster
 	local transform = CreateUnitByName("ward_familiar", caster:GetAbsOrigin(), true, caster, caster, caster:GetTeamNumber())
 
-	transform:AddNewModifier(caster, caster, "modifier_invisible", {}) 
-	transform:AddNewModifier(caster, caster, "modifier_item_ward_true_sight", {true_sight_range = 1600, duration = 105}) 
+	transform:AddNewModifier(caster, caster, "modifier_invisible", {})
+	transform:AddNewModifier(caster, caster, "modifier_item_ward_true_sight", {true_sight_range = 1600, duration = 105})
 	transform:AddNewModifier(caster, caster, "modifier_kill", {duration = 105})
-	caster:EmitSound("DOTA_Item.ObserverWard.Activate") 
+	caster:EmitSound("DOTA_Item.ObserverWard.Activate")
 	Timers:CreateTimer({
 		endTime = 0.1,
 		callback = function()
-		caster:RemoveSelf() 
+		caster:RemoveSelf()
 		return
 	end
 	})
@@ -299,7 +332,11 @@ end
 function SpiritLink(keys)
 	print("Spirit Link Used")
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local targets = keys.target_entities
 	--local targets = FindUnitsInRadius(caster:GetTeam(), caster:GetAbsOrigin(), nil, 1000, DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_HERO, 0, FIND_CLOSEST, false)
 	local linkTargets = {}
@@ -317,10 +354,10 @@ function SpiritLink(keys)
 	end
 
 	-- add list of linked targets to hero table
-	for i=1,#targets do	
+	for i=1,#targets do
 		targets[i].linkTable = linkTargets
 		print("Table Contents " .. i .. " : " .. targets[i]:GetName())
-		keys.ability:ApplyDataDrivenModifier(caster, targets[i], "modifier_share_damage", {}) 
+		keys.ability:ApplyDataDrivenModifier(caster, targets[i], "modifier_share_damage", {})
 	end
 end
 
@@ -331,7 +368,7 @@ function OnLinkDamageTaken(keys)
             if IsRevivePossible(hero) then hero:SetHealth(1) end
             hero:RemoveModifierByName("modifier_share_damage")
             RemoveHeroFromLinkTables(hero)
-        end    
+        end
     end)
 end
 
@@ -352,7 +389,7 @@ function Blink(keys)
 	local targetPoint = keys.target_points[1]
 	local newTargetPoint = nil
 
-	if IsLocked(caster) or caster:HasModifier("jump_pause_nosilence") then 
+	if IsLocked(caster) or caster:HasModifier("jump_pause_nosilence") then
 		keys.ability:EndCooldown()
 		SendErrorMessage(caster:GetPlayerOwnerID(), "#Cannot_Blink")
 		return
@@ -372,18 +409,18 @@ function Blink(keys)
 			SendErrorMessage(caster:GetPlayerOwnerID(), "#Cannot_Blink")
 			return
 		end
-	end 
+	end
 
 
 
 
 	if GridNav:IsBlocked(targetPoint) or not GridNav:IsTraversable(targetPoint) then
-		keys.ability:EndCooldown()  
+		keys.ability:EndCooldown()
 		SendErrorMessage(caster:GetPlayerOwnerID(), "#Cannot_Travel")
-		return 
-	end 
+		return
+	end
 
-	
+
 	-- particle
 	local particle = ParticleManager:CreateParticle("particles/items_fx/blink_dagger_start.vpcf", PATTACH_CUSTOMORIGIN, nil)
 	ParticleManager:SetParticleControl(particle, 0, casterPos)
@@ -393,12 +430,12 @@ function Blink(keys)
 
 	-- blink
 	local diff = targetPoint - caster:GetAbsOrigin()
-	if diff:Length() <= 1000 then 
+	if diff:Length() <= 1000 then
 		caster:SetAbsOrigin(targetPoint)
 		ProjectileManager:ProjectileDodge(caster)
 		--ParticleManager:SetParticleControl(particle2, 0, targetPoint)
 		EmitSoundOnLocationWithCaster(targetPoint, "Hero_Antimage.Blink_in", caster)
-	else  
+	else
 		newTargetPoint = caster:GetAbsOrigin() + diff:Normalized() * 1000
 		local i = 1
 		while GridNav:IsBlocked(newTargetPoint) or not GridNav:IsTraversable(newTargetPoint) or i == 100 do
@@ -406,12 +443,12 @@ function Blink(keys)
 			newTargetPoint = caster:GetAbsOrigin() + diff:Normalized() * (1000 - i*10)
 		end
 
-		caster:SetAbsOrigin(newTargetPoint) 
+		caster:SetAbsOrigin(newTargetPoint)
 		ProjectileManager:ProjectileDodge(caster)
 		ParticleManager:SetParticleControl(particle2, 0, caster:GetAbsOrigin())
 		EmitSoundOnLocationWithCaster(newTargetPoint, "Hero_Antimage.Blink_in", caster)
 	end
-	
+
 	FindClearSpaceForUnit(caster, caster:GetAbsOrigin(), true)
 
 	Timers:CreateTimer(2.0, function()
@@ -422,14 +459,14 @@ end
 
 function StashBlink(keys)
 	local caster = keys.caster
-	local casterinitloc = caster:GetAbsOrigin() 
+	local casterinitloc = caster:GetAbsOrigin()
 	local targetPoint = keys.target_points[1]
 	local hero = caster:GetPlayerOwner():GetAssignedHero()
 	caster:SetAbsOrigin(hero:GetAbsOrigin())
 	FindClearSpaceForUnit(caster, caster:GetAbsOrigin(), true)
-	
-	Timers:CreateTimer(8.0, function() 
-		caster:SetAbsOrigin(casterinitloc) 
+
+	Timers:CreateTimer(8.0, function()
+		caster:SetAbsOrigin(casterinitloc)
 		return
 	end)
 
@@ -441,7 +478,11 @@ end
 
 function CScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local pid = caster:GetPlayerID()
 	cdummy = CreateUnitByName("dummy_unit", caster:GetAbsOrigin(), true, caster, caster, caster:GetTeamNumber())
 	cdummy:AddNewModifier(caster, caster, "modifier_kill", {duration = 10})
@@ -449,7 +490,7 @@ function CScroll(keys)
 	dummy_passive:SetLevel(1)
 	local fire = cdummy:FindAbilityByName("dummy_c_scroll")
 	fire:SetLevel(1)
-	if fire:IsFullyCastable() then 
+	if fire:IsFullyCastable() then
 		cdummy:CastAbilityOnTarget(keys.target, fire, pid)
 	end
 
@@ -471,12 +512,12 @@ function CScrollHit(keys)
 	DoDamage(keys.caster:GetPlayerOwner():GetAssignedHero(), keys.target, 100, DAMAGE_TYPE_MAGICAL, 0, keys.ability, false)
 	keys.target:EmitSound("Hero_EmberSpirit.FireRemnant.Explode")
 	if not keys.target:IsMagicImmune() then
-		keys.target:AddNewModifier(keys.caster:GetPlayerOwner():GetAssignedHero(), keys.target, "modifier_stunned", {Duration = 1.0}) 
+		keys.target:AddNewModifier(keys.caster:GetPlayerOwner():GetAssignedHero(), keys.target, "modifier_stunned", {Duration = 1.0})
 	end
 end
 
 function CScrollEnd(keys)
-	local caster = keys.caster 
+	local caster = keys.caster
 	local target = keys.target
 	if IsValidEntity(caster) and not caster:IsNull() then
 		caster:RemoveSelf()
@@ -485,8 +526,11 @@ end
 
 function BScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
 	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability, "item_b_scroll")
+		return
+	end
 	ability:ApplyDataDrivenModifier(caster, caster, "modifier_b_scroll", {})
 	caster.BShieldAmount = keys.ShieldAmount
 	caster:EmitSound("DOTA_Item.ArcaneBoots.Activate")
@@ -495,8 +539,11 @@ end
 
 function AScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
 	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	ability:ApplyDataDrivenModifier(caster, caster, "modifier_a_scroll", {})
 	caster:EmitSound("Hero_Oracle.FatesEdict.Cast")
 end
@@ -504,13 +551,17 @@ end
 
 function SScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local target = keys.target
 	if IsSpellBlocked(keys.target) then return end
 
-	DoDamage(caster, target, 400, DAMAGE_TYPE_MAGICAL, 0, keys.ability, false)
+	DoDamage(caster, target, 400, DAMAGE_TYPE_MAGICAL, 0, ability, false)
 	ApplyPurge(target)
-	local boltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster) 
+	local boltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster)
 	ParticleManager:SetParticleControl(boltFx, 1, Vector(target:GetAbsOrigin().x,target:GetAbsOrigin().y,target:GetAbsOrigin().z+((target:GetBoundingMaxs().z - target:GetBoundingMins().z)/2)))
 
 	local lightningBoltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_leshrac/leshrac_lightning_bolt.vpcf", PATTACH_ABSORIGIN, target)
@@ -527,7 +578,11 @@ end
 
 function EXScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	local target = keys.target
 	if IsSpellBlocked(keys.target) then return end
 	local lightning = {
@@ -536,12 +591,12 @@ function EXScroll(keys)
 		damage = 600,
 		damage_type = DAMAGE_TYPE_MAGICAL,
 		damage_flags = 0,
-		ability = keys.ability
+		ability = ability
 	}
-	DoDamage(caster, target, 600, DAMAGE_TYPE_MAGICAL, 0, keys.ability, false)
+	DoDamage(caster, target, 600, DAMAGE_TYPE_MAGICAL, 0, ability, false)
 	ApplyPurge(target)
 
-	local boltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster) 
+	local boltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster)
 	--local lightningBoltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_leshrac/leshrac_lightning_bolt.vpcf", PATTACH_ABSORIGIN, target)
 	ParticleManager:SetParticleControl(boltFx, 1, Vector(target:GetAbsOrigin().x,target:GetAbsOrigin().y,target:GetAbsOrigin().z+((target:GetBoundingMaxs().z - target:GetBoundingMins().z)/2)))
 
@@ -551,14 +606,14 @@ function EXScroll(keys)
             , DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_ALL, DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE, FIND_CLOSEST, false)
 	for k,v in pairs(targets) do
 		if forkCount == 4 then return end
-		if v ~= target then 
+		if v ~= target then
 	        DoDamage(caster, v, 600, DAMAGE_TYPE_MAGICAL, 0, keys.ability, false)
-	        local bolt = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster) 
+	        local bolt = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster)
 	        ParticleManager:SetParticleControl(bolt, 1, Vector(v:GetAbsOrigin().x,v:GetAbsOrigin().y,v:GetAbsOrigin().z+((v:GetBoundingMaxs().z - v:GetBoundingMins().z)/2)))
 	        Timers:CreateTimer(2.0, function()
 				ParticleManager:DestroyParticle(bolt, false)
-			end) 
-			
+			end)
+
 			--ParticleManager:SetParticleControl(lightningBoltFx,0, caster:GetAbsOrigin())
 			--ParticleManager:SetParticleControl(lightningBoltFx,1, v:GetAbsOrigin())
 	        forkCount = forkCount + 1
@@ -576,8 +631,11 @@ end
 
 function HealingScroll(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
 	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 
 	local healFx = ParticleManager:CreateParticle("particles/units/heroes/hero_omniknight/omniknight_purification_g.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
 
@@ -585,7 +643,7 @@ function HealingScroll(keys)
             , DOTA_UNIT_TARGET_TEAM_FRIENDLY, DOTA_UNIT_TARGET_ALL, 0, FIND_ANY_ORDER, false)
 	for k,v in pairs(targets) do
 		ParticleManager:SetParticleControl(healFx, 1, v:GetAbsOrigin()) -- target effect location
-        v:Heal(500, caster) 
+        v:Heal(500, caster)
        	ability :ApplyDataDrivenModifier(caster, v, "modifier_healing_scroll", {})
     end
 
@@ -596,8 +654,11 @@ end
 
 function AntiMagic(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
 	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 	caster:EmitSound("DOTA_Item.BlackKingBar.Activate")
 	ability:ApplyDataDrivenModifier(caster, caster, "modifier_magic_immunity", {})
 
@@ -605,11 +666,15 @@ end
 
 function FullHeal(keys)
 	local caster = keys.caster
-	if caster:HasModifier("jump_pause_nosilence") then keys.ability:EndCooldown() return end
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
 
 	if caster:GetHealth() == caster:GetMaxHealth() and caster:GetMana() == caster:GetMaxMana() then keys.ability:EndCooldown() return end
-	
-	caster:SetHealth(caster:GetMaxHealth()) 
+
+	caster:SetHealth(caster:GetMaxHealth())
 	caster:SetMana(caster:GetMaxMana())
 
 	caster:EmitSound("DOTA_Item.Mekansm.Activate")


### PR DESCRIPTION
Fixes #79. Should also fix #77,

- [x] Mana Essence (needs change to RunScript instead of applying modifier right away)
- [x] Speed Gem (needs change to RunScript instead of applying modifier right away)
- [x] Berserk Scroll (needs change to RunScript instead of applying modifier right away)
- [x] Condensed Mana Essence (check for 1 and 2 charges)
- [x] TP Scroll
- [x] Ward Familiar
- [x] Scout Familiar
- [x] Spirit Link
- [x] Blink
- [x] C Scroll
- [x] B Scroll
- [x] A Scroll
- [x] S Scroll (slow and lock still applied. See #85)
- [x] EX Scroll (slow and lock still applied. See #85)
- [x] Heal Scroll
- [x] Shard of Antimagic (check for 1 and more than 1 charges)
- [x] Shard of Replenishment (check for 1 and more than 1 charges)

Important: EX and S do not go on cooldown and still apply the modifier so it is possible to permanently lock someone in place during Black Rider's combo.

When an item needs to be refunded but has consumed all its charges, it is considered removed from the inventory and increasing its charges will not refund it. As a workaround, a new item is created, but since it uses `AddItem`, it is placed in the first available inventory slot.

However, if the item's `SpendCharge` is put after its `RunScript`, then its charges are not spent until after refunding, meaning it gets to keep its original position. Currently only A Scroll has such a behavior. Not entirely sure of the effects of putting `SpendCharge` after `RunScript`, but seems like a possible QoL improvement (not implemented yet).