### PR TITLE
Added Alt-Click functionality for UI Timers

### DIFF
--- a/content/dota_addons/fateanother/panorama/layout/custom_game/fateanother_timer.xml
+++ b/content/dota_addons/fateanother/panorama/layout/custom_game/fateanother_timer.xml
@@ -4,9 +4,9 @@
         <include src="file://{resources}/styles/custom_game/fateanother_timer.css" />
     </styles>
     <scripts>
-        <include src="file://{resources}/scripts/custom_game/fateanother_timer.js" /> 
+        <include src="file://{resources}/scripts/custom_game/fateanother_timer.js" />
     </scripts>
-    <Panel class="TimerBody" hittest="false">
+    <Panel class="TimerBody" hittest="true">
         <Label id="TimerMsg" text="Round"/>
         <Label id="TimerRemaining" text="00:00:00"/>
     </Panel>

--- a/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_timer.js
+++ b/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_timer.js
@@ -44,6 +44,16 @@ function SetTimer( message, duration )
 	});
 }
 
+function TimerClicked() {
+	if (!GameUI.IsAltDown()) {
+		return;
+	}
+	var messageLabel = $("#TimerMsg");
+	var timeLabel = $("#TimerRemaining");
+	var message = messageLabel.text + " ▶ " + timeLabel.text
+	GameEvents.SendCustomGameEventToServer("player_alt_click", {message: message});
+}
+
 
 function UpdateTimer(message, duration)
 {
@@ -53,6 +63,7 @@ function UpdateTimer(message, duration)
 (function()
 {
 	$.GetContextPanel().SetTimer = SetTimer;
+	$.GetContextPanel().TimerClicked = TimerClicked;
 	//GameEvents.Subscribe( "dota_ability_changed", RebuildAbilityUI ); // major rebuild
 	//AutoUpdateAbility(); // initial update of dynamic state
 })();

--- a/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_timer_layout.js
+++ b/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_timer_layout.js
@@ -13,7 +13,7 @@ function CreateTimer(data) {
 	var desc = data.timerDescription;
 	var timerPanel = 0;
 	//If timer is already present
-	if (desc in timerTable) 
+	if (desc in timerTable)
 	{
 		if (timerTable[desc] == null)
 		{
@@ -25,7 +25,7 @@ function CreateTimer(data) {
 			$.Msg("object is already present, deleting if new duration input is 0");
 			timerPanel = timerTable[desc]
 			timerTable[desc].RemoveAndDeleteChildren();
-			delete timerTable[desc];	
+			delete timerTable[desc];
 			//return;
 		}
 	}
@@ -36,6 +36,10 @@ function CreateTimer(data) {
 	timerTable[desc] = timerPanel;
 	timerPanel.BLoadLayout("file://{resources}/layout/custom_game/fateanother_timer.xml", false, false );
 	timerPanel.SetTimer(message, duration);
+	timerPanel.SetPanelEvent(
+		"onactivate",
+		timerPanel.TimerClicked
+	);
 }
 
 

--- a/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
@@ -80,7 +80,7 @@ TRIO_RUMBLE_CENTER = Vector(2436,4132,1000)
 FFA_CENTER = Vector(368,3868,1000)
 mode = nil
 FATE_VERSION = "v1.16d"
-roundQuest = nil 
+roundQuest = nil
 IsGameStarted = false
 
 -- XP and XP Bounty stuffs
@@ -100,7 +100,7 @@ end
 _G.XP_PER_LEVEL_TABLE[MAX_LEVEL-1] = _G.XP_PER_LEVEL_TABLE[MAX_LEVEL-2] + 2400
 
 for i=1, MAX_LEVEL do
-    BOUNTY_PER_LEVEL_TABLE[i] = 1025 + i * 75 
+    BOUNTY_PER_LEVEL_TABLE[i] = 1025 + i * 75
 end
 
 XP_BOUNTY_PER_LEVEL_TABLE[1] = 120
@@ -201,14 +201,14 @@ end
 function Precache( context )
     print("Starting precache")
     --PrecacheUnitByNameSync("npc_precache_everything", context)
-    
+
     --PrecacheResource("soundfile", "soundevents/music/*.vsndevts", context)
     --[[Kill the default sound files
     PrecacheResource("soundfile", "soundevents/music/valve_dota_001/soundevents_stingers.vsndevts", context)
     PrecacheResource("soundfile", "soundevents/music/valve_dota_001/soundevents_music.vsndevts", context)
     PrecacheResource("soundfile", "soundevents/music/valve_dota_001/game_sounds_music.vsndevts", context)
     PrecacheResource("soundfile", "soundevents/music/valve_dota_001/music/game_sounds_music.vsndevts", context)
-    
+
     PrecacheResource("soundfile", "soundevents/bgm.vsndevts", context)]]
     -- Sound files
     PrecacheResource("soundfile", "soundevents/bgm.vsndevts", context)
@@ -264,7 +264,7 @@ function Precache( context )
     PrecacheItemByNameSync("item_all_seeing_orb", context)
     PrecacheItemByNameSync("item_shard_of_anti_magic", context)
     PrecacheItemByNameSync("item_shard_of_replenishment", context)
-    
+
     -- Master, Stash, and System stuffs
     PrecacheResource("model", "models/shirou/shirouanim.vmdl", context)
     PrecacheResource("model", "models/items/courier/catakeet/catakeet_boxes.vmdl", context)
@@ -303,7 +303,7 @@ function Precache( context )
     PrecacheResource("model", "models/astolfo/astolfo_horn.vmdl", context)
     PrecacheResource("model", "models/astolfo/astolfo_sword.vmdl", context)
     PrecacheResource("model", "models/nurseryrhyme/nurseryrhyme.vmdl", context)
-    
+
     -- AOTK Soldier assets
     PrecacheResource("model_folder", "models/heroes/chen", context)
     PrecacheResource("model_folder", "models/items/chen", context)
@@ -318,12 +318,12 @@ function Precache( context )
 
     -- Vector target
     --VectorTarget:Precache( context )
-    
+
     print("precache complete")
 end
 
 function FateGameMode:PostLoadPrecache()
-    print("[BAREBONES] Performing Post-Load precache") 
+    print("[BAREBONES] Performing Post-Load precache")
     --PrecacheItemByNameAsync("item_example_item", function(...) end)
     --PrecacheItemByNameAsync("example_ability", function(...) end)
     PrecacheUnitByNameAsync("npc_dota_hero_legion_commander", function(...) end)
@@ -362,7 +362,7 @@ function FateGameMode:OnAllPlayersLoaded()
     --GameRules:SendCustomMessage("Game is currently in alpha phase of development and you may run into major issues that I hope to address ASAP. Please wait patiently for the official release.", 0, 0)
     GameRules:SendCustomMessage("#Fate_Choose_Hero_Alert_60", 0, 0)
     FireGameEvent('cgm_timer_display', { timerMsg = "Hero Select", timerSeconds = 61, timerEnd = true, timerPosition = 100})
-    
+
     -- initialize vector targeting
     --VectorTarget:Init({noOrderFilter = true })
     -- Send KV to fatepedia
@@ -408,7 +408,7 @@ function FateGameMode:OnAllPlayersLoaded()
     Timers:CreateTimer('30secondalert', {
         endTime = 30,
         callback = function()
-            
+
         GameRules:SendCustomMessage("#Fate_Choose_Hero_Alert_30_1", 0, 0)
         GameRules:SendCustomMessage("#Fate_Choose_Hero_Alert_30_2", 0, 0)
         DisplayTip()
@@ -425,13 +425,13 @@ function FateGameMode:OnAllPlayersLoaded()
                 self.nCurrentRound = 1
                 self:InitializeRound() -- Start the game after forcing a pick for every player
                 BLESSING_PERIOD = 600
-            elseif _G.GameMap == "fate_ffa" then 
+            elseif _G.GameMap == "fate_ffa" then
                 BLESSING_PERIOD = 300
                 SHARD_DROP_PERIOD = 180
                 CENTER_POSITION = FFA_CENTER
                 CreateUITimer("Next Holy Grail's Shard", SHARD_DROP_PERIOD, "shard_drop_timer")
                 _G.CurrentGameState = "FATE_ROUND_ONGOING"
-            elseif _G.GameMap == "fate_trio_rumble_3v3v3v3" then 
+            elseif _G.GameMap == "fate_trio_rumble_3v3v3v3" then
                 BLESSING_PERIOD = 300
                 SHARD_DROP_PERIOD = 180
                 CENTER_POSITION = TRIO_RUMBLE_CENTER
@@ -445,7 +445,7 @@ function FateGameMode:OnAllPlayersLoaded()
             GameRules:SendCustomMessage("#Fate_Game_Begin", 0, 0)
             CreateUITimer("Next Holy Grail's Blessing", FIRST_BLESSING_PERIOD, "ten_min_timer")
             self:LoopOverPlayers(function(player, playerID, playerHero)
-                playerHero:RemoveModifierByName("round_pause") 
+                playerHero:RemoveModifierByName("round_pause")
             end)
             Timers:CreateTimer('round_10min_bonus', {
                 endTime = FIRST_BLESSING_PERIOD,
@@ -453,8 +453,8 @@ function FateGameMode:OnAllPlayersLoaded()
                     CreateUITimer("Next Holy Grail's Blessing", BLESSING_PERIOD, "ten_min_timer")
                     self:LoopOverPlayers(function(player, playerID, playerHero)
                         local hero = playerHero
-                        hero.MasterUnit:SetHealth(hero.MasterUnit:GetMaxHealth()) 
-                        hero.MasterUnit:SetMana(hero.MasterUnit:GetMana()+BLESSING_MANA_REWARD) 
+                        hero.MasterUnit:SetHealth(hero.MasterUnit:GetMaxHealth())
+                        hero.MasterUnit:SetMana(hero.MasterUnit:GetMana()+BLESSING_MANA_REWARD)
                         hero.MasterUnit2:SetHealth(hero.MasterUnit2:GetMaxHealth())
                         hero.MasterUnit2:SetMana(hero.MasterUnit2:GetMana()+BLESSING_MANA_REWARD)
                         MinimapEvent( hero:GetTeamNumber(), hero, hero.MasterUnit:GetAbsOrigin().x, hero.MasterUnit2:GetAbsOrigin().y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 2 )
@@ -462,7 +462,7 @@ function FateGameMode:OnAllPlayersLoaded()
                     --Notifications:TopToAll("#Fate_Timer_10minute", 5, nil, {color="rgb(255,255,255)", ["font-size"]="25px"})
                     Notifications:TopToAll({text="#Fate_Timer_10minute", duration=5.0, style={color="rgb(255,255,255)", ["font-size"]="25px"}})
 
-                    
+
                     return BLESSING_PERIOD
             end})
             if _G.GameMap == "fate_trio_rumble_3v3v3v3" or _G.GameMap == "fate_ffa" then
@@ -526,7 +526,7 @@ end
 function FateGameMode:OnDisconnect(keys)
     print('[BAREBONES] Player Disconnected ' .. tostring(keys.userid))
     --PrintTable(keys)
-    
+
     local name = keys.name
     local networkid = keys.networkid
     local reason = keys.reason
@@ -538,7 +538,7 @@ function FateGameMode:OnDisconnect(keys)
 end
 
 function SendChatToPanorama(string)
-    local table = 
+    local table =
     {
         text = string
     }
@@ -585,11 +585,11 @@ function FateGameMode:OnPlayerChat(keys)
                 hero.MasterUnit2:SetHealth(1000)
                 if hero:GetName() == "npc_dota_hero_juggernaut" then
                     hero:SetBaseStrength(25)
-                    hero:SetBaseAgility(25) 
-                else 
-                    hero:SetBaseStrength(20) 
-                    hero:SetBaseAgility(20) 
-                    hero:SetBaseIntellect(20) 
+                    hero:SetBaseAgility(25)
+                else
+                    hero:SetBaseStrength(20)
+                    hero:SetBaseAgility(20)
+                    hero:SetBaseIntellect(20)
                 end
             end)
         end
@@ -599,7 +599,7 @@ function FateGameMode:OnPlayerChat(keys)
         local hr = plyr:GetAssignedHero()
         hr:RemoveModifierByName("round_pause")
     end]]
-        if GameRules:IsCheatMode() then 
+        if GameRules:IsCheatMode() then
             self:LoopOverPlayers(function(player, playerID, playerHero)
                 local hr = playerHero
                 hr:RemoveModifierByName("round_pause")
@@ -612,34 +612,34 @@ function FateGameMode:OnPlayerChat(keys)
         local hr = plyr:GetAssignedHero()
         hr:RemoveModifierByName("round_pause")
     end]]
-        if GameRules:IsCheatMode() then 
+        if GameRules:IsCheatMode() then
             SendErrorMessage(plyID, "#test_msg")
         end
     end
 
 
     if text == "-declarewinner" then
-        if Convars:GetBool("sv_cheats") then 
+        if Convars:GetBool("sv_cheats") then
             GameRules:SetGameWinner( DOTA_TEAM_GOODGUYS )
         end
     end
     -- manually end the round
     if text == "-finishround" then
-        if Convars:GetBool("sv_cheats") then 
-            self:FinishRound(true, 1) 
+        if Convars:GetBool("sv_cheats") then
+            self:FinishRound(true, 1)
         end
     end
-        
+
 
     if text == "-tt" then
-        if Convars:GetBool("sv_cheats") then 
+        if Convars:GetBool("sv_cheats") then
             hero.ShardAmount = 10
             print("10 shards")
         end
     end
-    
+
     if text == "-silence" then
-        if Convars:GetBool("sv_cheats") then 
+        if Convars:GetBool("sv_cheats") then
             EmitGlobalSound("Silence_Test")
         end
     end
@@ -658,11 +658,11 @@ function FateGameMode:OnPlayerChat(keys)
         --if GameRules:IsCheatMode() then
         --SendChatToPanorama("player " .. plyID .. " is trying to send " .. goldAmt .. " gold to player " .. pID)
         --end
-        if PlayerResource:GetReliableGold(plyID) > tonumber(goldAmt) and plyID ~= tonumber(pID) and PlayerResource:GetTeam(plyID) == PlayerResource:GetTeam(tonumber(pID)) then 
+        if PlayerResource:GetReliableGold(plyID) > tonumber(goldAmt) and plyID ~= tonumber(pID) and PlayerResource:GetTeam(plyID) == PlayerResource:GetTeam(tonumber(pID)) then
             local targetHero = PlayerResource:GetPlayer(tonumber(pID)):GetAssignedHero()
-            hero:ModifyGold(-tonumber(goldAmt), true , 0) 
+            hero:ModifyGold(-tonumber(goldAmt), true , 0)
             targetHero:ModifyGold(tonumber(goldAmt), true, 0)
-            
+
             --GameRules:SendCustomMessage("<font color='#58ACFA'>" .. hero.name .. "</font> sent " .. goldAmt .. " gold to <font color='#58ACFA'>" .. targetHero.name .. "</font>" , hero:GetTeamNumber(), hero:GetPlayerOwnerID())
         end
     end
@@ -696,7 +696,7 @@ function FateGameMode:OnPlayerChat(keys)
             end)
         end
     end
-   
+
     if text == "-sealtest" then
         if Convars:GetBool("sv_cheats") then
             hero.MasterUnit:SetMana(10)
@@ -711,15 +711,27 @@ function FateGameMode:OnPlayerChat(keys)
     end
 end
 
+function OnPlayerAltClick(eventSourceIndex, keys)
+	local playerId = keys.PlayerID
+	local player = PlayerResource:GetPlayer(playerId)
+	local altClickTime = player.altClickTime
+	local currentTime = GetSystemTime()
+	if currentTime == altClickTime then
+		return
+	end
+	player.altClickTime = currentTime
+	Say(player, keys.message, keys.toAll and false or true)
+end
+
 function DistributeGold(hero, cutoff)
-    -- get gold amount of teammates 
+    -- get gold amount of teammates
     -- exclude from table if more than stated amount
     -- sort them by amount of current gold
     local playerTable = {}
     local playerID = hero:GetPlayerID()
     if PlayerResource:GetReliableGold(playerID) < cutoff then return end
     LoopOverPlayers(function(ply, plyID, playerHero)
-        if playerHero:GetTeamNumber() == hero:GetTeamNumber() and plyID ~= playerID then 
+        if playerHero:GetTeamNumber() == hero:GetTeamNumber() and plyID ~= playerID then
             local pGold = PlayerResource:GetReliableGold(plyID)
             if pGold < 5000 then
                 playerTable[plyID] = pGold
@@ -732,7 +744,7 @@ function DistributeGold(hero, cutoff)
     local residue = 0
     local goldPerPerson =  (PlayerResource:GetReliableGold(playerID)-cutoff)/#playerTable
 
-    -- eligible players 
+    -- eligible players
     for pID,curGold in spairs(playerTable, function(t,a,b) return t[b] < t[a] end) do
         local eligibleGoldAmt = 5000 - PlayerResource:GetReliableGold(pID)
         -- only grant eligible amount of gold and save the rest on residue
@@ -752,7 +764,7 @@ function DistributeGold(hero, cutoff)
 end
 
 function DistributeGoldV2(hero, cutoff)
-    -- get gold amount of teammates 
+    -- get gold amount of teammates
     -- exclude from table if more than stated amount
     -- sort them by amount of current gold
     local goldTable = {}
@@ -760,7 +772,7 @@ function DistributeGoldV2(hero, cutoff)
     local playerID = hero:GetPlayerID()
     if PlayerResource:GetReliableGold(playerID) < cutoff then return end
     LoopOverPlayers(function(ply, plyID, playerHero)
-        if playerHero:GetTeamNumber() == hero:GetTeamNumber() and plyID ~= playerID then 
+        if playerHero:GetTeamNumber() == hero:GetTeamNumber() and plyID ~= playerID then
             local pGold = PlayerResource:GetReliableGold(plyID)
             if pGold < 4950 then
                 table.insert(goldTable, pGold)
@@ -775,7 +787,7 @@ function DistributeGoldV2(hero, cutoff)
     local residue = 0
     local goldPerPerson =  math.floor((PlayerResource:GetReliableGold(playerID)-cutoff)/#plyIDTable)
 
-    -- eligible players 
+    -- eligible players
     for k,curGold in spairs(goldTable, function(t,a,b) return t[b] < t[a] end) do
         local eligibleGoldAmt = 4950 - PlayerResource:GetReliableGold(plyIDTable[k])
         -- only grant eligible amount of gold and save the rest on residue
@@ -793,7 +805,7 @@ end
 -- The overall game state has changed
 function FateGameMode:OnGameRulesStateChange(keys)
     print("[BAREBONES] GameRules State Changed")
-    
+
     local newState = GameRules:State_Get()
     if newState == DOTA_GAMERULES_STATE_WAIT_FOR_PLAYERS_TO_LOAD then
         self.bSeenWaitForPlayers = true
@@ -813,7 +825,7 @@ function FateGameMode:OnNPCSpawned(keys)
     --print("[BAREBONES] NPC Spawned")
     --PrintTable(keys)
     local hero = EntIndexToHScript(keys.entindex)
-    
+
     if hero:IsRealHero() and hero.bFirstSpawned == nil and hero:GetPlayerOwner() ~= nil then
         FateGameMode:OnHeroInGame(hero)
     end
@@ -828,7 +840,7 @@ This function is called once and only once for every player when they spawn into
 function FateGameMode:OnHeroInGame(hero)
     --print("[BAREBONES] Hero spawned in game for first time -- " .. hero:GetUnitName())
     --Add a non-player hero to player list if it's missing(i.e generated by -createhero)
-    if self.vBots[hero:GetPlayerID()] == 1 then 
+    if self.vBots[hero:GetPlayerID()] == 1 then
         print((hero:GetPlayerID()) .." is a bot!")
         self.vPlayerList[hero:GetPlayerID()] = hero:GetPlayerID()
     end
@@ -837,7 +849,7 @@ function FateGameMode:OnHeroInGame(hero)
     hero.bFirstSpawned = true
     hero.PresenceTable = {}
     hero.bIsDmgPopupDisabled = false
-    hero.bIsAlertSoundDisabled = false 
+    hero.bIsAlertSoundDisabled = false
     hero:SetAbilityPoints(0)
     hero:SetGold(0, false)
     hero.OriginalModel = hero:GetModelName()
@@ -850,7 +862,7 @@ function FateGameMode:OnHeroInGame(hero)
 
 
     Timers:CreateTimer(1.0, function()
-        if hero:GetTeam() == 2 then 
+        if hero:GetTeam() == 2 then
             if self.nCurrentRound == 0 or self.nCurrentRound == 1 then
                 hero.RespawnPos = SPAWN_POSITION_RADIANT_DM
             elseif self.nCurrentRound % 2 == 0 then
@@ -862,7 +874,7 @@ function FateGameMode:OnHeroInGame(hero)
             elseif self.nCurrentRound % 2 == 0 then
                 hero.RespawnPos = SPAWN_POSITION_RADIANT_DM
             end
-        end 
+        end
         --print("Respawn location registered : " .. hero.RespawnPos.x .. " BY " .. hero:GetName() )
     end)
     hero.bIsDirectTransferEnabled = true -- True by default
@@ -870,10 +882,10 @@ function FateGameMode:OnHeroInGame(hero)
     -- Set music off
     local player = PlayerResource:GetPlayer(hero:GetPlayerID())
     player:SetMusicStatus(DOTA_MUSIC_STATUS_NONE, 100000)
-    
+
     -- Create Command Seal master for hero
     master = CreateUnitByName("master_1", Vector(4500 + hero:GetPlayerID()*320,-7050,0), true, hero, hero, hero:GetTeamNumber())
-    master:SetControllableByPlayer(hero:GetPlayerID(), true) 
+    master:SetControllableByPlayer(hero:GetPlayerID(), true)
     master:SetMana(0)
     hero.MasterUnit = master
     LevelAllAbility(master)
@@ -884,10 +896,10 @@ function FateGameMode:OnHeroInGame(hero)
     master:AddItem(CreateItem("item_master_transfer_items5", nil, nil))
     master:AddItem(CreateItem("item_master_transfer_items6", nil, nil))
     MinimapEvent( hero:GetTeamNumber(), hero, master:GetAbsOrigin().x, master:GetAbsOrigin().y + 500, DOTA_MINIMAP_EVENT_HINT_LOCATION, 5 )
-    
+
     -- Create attribute/stat master for hero
     master2 = CreateUnitByName("master_2", Vector(4500 + hero:GetPlayerID()*320,-7400,0), true, hero, hero, hero:GetTeamNumber())
-    master2:SetControllableByPlayer(hero:GetPlayerID(), true) 
+    master2:SetControllableByPlayer(hero:GetPlayerID(), true)
     master2:SetMana(0)
     hero.MasterUnit2 = master2
     AddMasterAbility(master2, hero:GetName())
@@ -923,7 +935,7 @@ function FateGameMode:OnHeroInGame(hero)
     master3:AddAbility("master_item_transfer_5")
     master3:AddAbility("master_item_transfer_6")
     master3:AddAbility("master_passive")
-    LevelAllAbility(master3)  
+    LevelAllAbility(master3)
 
 
     -- Ping master location on minimap
@@ -938,8 +950,8 @@ function FateGameMode:OnHeroInGame(hero)
     if _G.GameMap == "fate_elim_6v6" then
         if self.nCurrentRound == 0 then
             giveUnitDataDrivenModifier(hero, hero, "round_pause", 60)
-        elseif self.nCurrentRound >= 1 then 
-            hero:ModifyGold(3000, true, 0) 
+        elseif self.nCurrentRound >= 1 then
+            hero:ModifyGold(3000, true, 0)
             giveUnitDataDrivenModifier(hero, hero, "round_pause", 10)
         end
     else
@@ -949,17 +961,17 @@ function FateGameMode:OnHeroInGame(hero)
         end
     end
 
-    if Convars:GetBool("sv_cheats") then 
+    if Convars:GetBool("sv_cheats") then
         hero:RemoveModifierByName("round_pause")
-        hero.MasterUnit:SetMana(hero.MasterUnit:GetMaxMana()) 
+        hero.MasterUnit:SetMana(hero.MasterUnit:GetMaxMana())
         hero.MasterUnit2:SetMana(hero.MasterUnit2:GetMaxMana())
 
-        hero:SetBaseStrength(20) 
-        hero:SetBaseAgility(20) 
-        hero:SetBaseIntellect(20) 
+        hero:SetBaseStrength(20)
+        hero:SetBaseAgility(20)
+        hero:SetBaseIntellect(20)
     end
 
-    
+
     -- Wait 1 second for loadup
     Timers:CreateTimer(1.0, function()
         if _G.GameMap == "fate_ffa" or _G.GameMap == "fate_trio_rumble_3v3v3v3" then
@@ -981,7 +993,7 @@ end
 
 -- This is for swapping hero models in
 function FateGameMode:OnHeroSpawned( keys )
-    
+
 end
 
 -- An entity somewhere has been hurt. This event fires very often with many units so don't do too many expensive
@@ -995,7 +1007,7 @@ end
 
 -- An item was picked up off the ground
 function FateGameMode:OnItemPickedUp(keys)
-    
+
     local heroEntity = nil
     local player = nil
     local item = EntIndexToHScript( keys.ItemEntityIndex )
@@ -1049,7 +1061,7 @@ end
 -- state as necessary
 function FateGameMode:OnPlayerReconnect(keys)
     print ( '[BAREBONES] OnPlayerReconnect' )
-    --PrintTable(keys) 
+    --PrintTable(keys)
     Timers:CreateTimer(3.0, function()
         print("reinitiating the UI")
         local userid = keys.PlayerID
@@ -1070,24 +1082,24 @@ end
 function FateGameMode:OnItemPurchased( keys )
     --print ( '[BAREBONES] OnItemPurchased : Purchased ' .. keys.itemname )
     --PrintTable(keys)
-    
+
     -- The playerID of the hero who is buying something
     local plyID = keys.PlayerID
     local ply = PlayerResource:GetPlayer(plyID)
     if not plyID then return end
-    
+
     -- The name of the item purchased
-    local itemName = keys.itemname 
+    local itemName = keys.itemname
     -- The cost of the item purchased
     local itemCost = keys.itemcost
-    
+
     local hero = PlayerResource:GetPlayer(plyID):GetAssignedHero()
     CheckItemCombinationInStash(hero)
 
     local oldStash = GetStashItems(hero)
-    
-    
-    
+
+
+
     if hero.IsInBase == false then
         if PlayerResource:GetGold(plyID) + itemCost < itemCost * 1.5 then
             -- This will take care of non-component items
@@ -1102,16 +1114,16 @@ function FateGameMode:OnItemPurchased( keys )
             end
         else
             --print("Deducing extra cost" .. itemCost*0.5 .. "from player gold")
-            hero:ModifyGold(-itemCost*0.5, true , 0) 
+            hero:ModifyGold(-itemCost*0.5, true , 0)
         end
         -- If hero is in base, check for C scroll stock
     else
         -- If hero is in base, check for C scroll stock
         if itemName == "item_c_scroll" then
-            if hero.CStock > 0 then 
+            if hero.CStock > 0 then
                 hero.CStock = hero.CStock - 1
 
-            else 
+            else
                 for i = 1, #oldStash do
                     if oldStash[i]:GetName() == "item_c_scroll" then
                         SendErrorMessage(plyID, "#Out_Of_Stock_C_Scroll")
@@ -1133,7 +1145,7 @@ end
 function GetStashItems(hero)
     local stashTable = {}
     for i=6,11 do
-        local heroItem = hero:GetItemInSlot(i) 
+        local heroItem = hero:GetItemInSlot(i)
         if heroItem ~= nil then
             table.insert(stashTable, heroItem)
         end
@@ -1143,14 +1155,14 @@ end
 
 function FindItemInStash(hero, itemname)
     for i=6, 11 do
-        local heroItem = hero:GetItemInSlot(i) 
+        local heroItem = hero:GetItemInSlot(i)
         if heroItem == nil then return nil end
         if heroItem:GetName() == itemname then
             return heroItem
         end
     end
     return nil
-end 
+end
 
 
 -- stash1 : old stash
@@ -1163,11 +1175,11 @@ function FindStashDifference(stash1, stash2)
             if stash1[j] == stash2[i] then IsItemFound = true break end -- Set flag to true and break from inner loop if same item is found
         end
         -- If item was not found, add item to return table
-        if IsItemFound == false then 
+        if IsItemFound == false then
             table.insert(addedItems, stash2[i])
         end
     end
-    
+
     return addedItems
 end
 
@@ -1226,7 +1238,7 @@ end
 function FateGameMode:OnNonPlayerUsedAbility(keys)
     --print('[BAREBONES] OnNonPlayerUsedAbility')
     --PrintTable(keys)
-    
+
     local abilityname= keys.abilityname
 end
 
@@ -1234,7 +1246,7 @@ end
 function FateGameMode:OnPlayerChangedName(keys)
     print('[BAREBONES] OnPlayerChangedName')
     --PrintTable(keys)
-    
+
     local newName = keys.newname
     local oldName = keys.oldName
 end
@@ -1243,7 +1255,7 @@ end
 function FateGameMode:OnPlayerLearnedAbility( keys)
     --print ('[BAREBONES] OnPlayerLearnedAbility')
     --PrintTable(keys)
-    
+
     local player = EntIndexToHScript(keys.player)
     local abilityname = keys.abilityname
 end
@@ -1252,7 +1264,7 @@ end
 function FateGameMode:OnAbilityChannelFinished(keys)
     --print ('[BAREBONES] OnAbilityChannelFinished')
     --PrintTable(keys)
-    
+
     local abilityname = keys.abilityname
     local interrupted = keys.interrupted == 1
 end
@@ -1261,14 +1273,14 @@ end
 function FateGameMode:OnPlayerLevelUp(keys)
     --print ('[BAREBONES] OnPlayerLevelUp')
     --PrintTable(keys)
-    
+
     local player = EntIndexToHScript(keys.player)
-    local hero = player:GetAssignedHero() 
+    local hero = player:GetAssignedHero()
     local level = keys.level
     hero.MasterUnit:SetMana(hero.MasterUnit:GetMana() + 3)
     hero.MasterUnit2:SetMana(hero.MasterUnit2:GetMana() + 3)
     --Notifications:Top(player, "<font color='#58ACFA'>" .. FindName(hero:GetName()) .. "</font> has gained a level. Master has received <font color='#58ACFA'>3 mana.</font>", 5, nil, {color="rgb(255,255,255)", ["font-size"]="20px"})
-    
+
     Notifications:Top(player, {text= "<font color='#58ACFA'>" .. FindName(hero:GetName()) .. "</font> has gained a level. Master has received <font color='#58ACFA'>3 mana.</font>", duration=5, style={color="rgb(255,255,255)", ["font-size"]="20px"}, continue=true})
     MinimapEvent( hero:GetTeamNumber(), hero, hero.MasterUnit:GetAbsOrigin().x, hero.MasterUnit2:GetAbsOrigin().y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 2 )
 end
@@ -1277,7 +1289,7 @@ end
 function FateGameMode:OnLastHit(keys)
     --print ('[BAREBONES] OnLastHit')
     --PrintTable(keys)
-    
+
     local isFirstBlood = keys.FirstBlood == 1
     local isHeroKill = keys.HeroKill == 1
     local isTowerKill = keys.TowerKill == 1
@@ -1297,7 +1309,7 @@ end
 function FateGameMode:OnTeamKillCredit(keys)
     --print ('[BAREBONES] OnTeamKillCredit')
     --PrintTable(keys)
-    local p = keys.splitscreenplayer 
+    local p = keys.splitscreenplayer
     local killerPlayer = PlayerResource:GetPlayer(keys.killer_userid)
     local victimPlayer = PlayerResource:GetPlayer(keys.victim_userid)
     local numKills = keys.herokills
@@ -1309,12 +1321,12 @@ end
 function FateGameMode:OnEntityKilled( keys )
     --print( '[BAREBONES] OnEntityKilled Called' )
     --PrintTable( keys )
-    
+
     -- The Unit that was Killed
     local killedUnit = EntIndexToHScript( keys.entindex_killed )
     -- The Killing entity
     local killerEntity = nil
-    
+
     if keys.entindex_attacker ~= nil then
         killerEntity = EntIndexToHScript( keys.entindex_attacker )
     end
@@ -1327,10 +1339,10 @@ function FateGameMode:OnEntityKilled( keys )
             end
         end
     end
-    -- Change killer to be owning hero 
+    -- Change killer to be owning hero
     if not killerEntity:IsHero() then
         --print("Killed by neutral unit")
-        if IsValidEntity(killerEntity:GetPlayerOwner()) then 
+        if IsValidEntity(killerEntity:GetPlayerOwner()) then
             killerEntity = killerEntity:GetPlayerOwner():GetAssignedHero()
         end
     end
@@ -1363,7 +1375,7 @@ function FateGameMode:OnEntityKilled( keys )
             end
             -- check if unit can receive a shard
             if killedUnit.DeathCount == 7 then
-                if killedUnit.ShardAmount == nil then 
+                if killedUnit.ShardAmount == nil then
                     killedUnit.ShardAmount = 1
                     killedUnit.DeathCount = 0
                 else
@@ -1385,16 +1397,16 @@ function FateGameMode:OnEntityKilled( keys )
             for i=1, #alliedHeroes do
                 if alliedHeroes[i]:IsHero() then
                     alliedHeroes[i]:AddExperience(XP_BOUNTY_PER_LEVEL_TABLE[killedUnit:GetLevel()]/realHeroCount, false, false)
-                end               
+                end
             end
 
-            -- Give kill bounty 
+            -- Give kill bounty
             local bounty = BOUNTY_PER_LEVEL_TABLE[killedUnit:GetLevel()]
             killerEntity:ModifyGold(bounty , true, 0)
             -- if killer has Golden Rule attribute, grant 50% more gold
-            if killerEntity:FindAbilityByName("gilgamesh_golden_rule") and killerEntity:FindAbilityByName("gilgamesh_golden_rule"):GetLevel() == 2 then 
-                killerEntity:ModifyGold(BOUNTY_PER_LEVEL_TABLE[killedUnit:GetLevel()] / 2, true, 0) 
-            end 
+            if killerEntity:FindAbilityByName("gilgamesh_golden_rule") and killerEntity:FindAbilityByName("gilgamesh_golden_rule"):GetLevel() == 2 then
+                killerEntity:ModifyGold(BOUNTY_PER_LEVEL_TABLE[killedUnit:GetLevel()] / 2, true, 0)
+            end
             --Granting XP to all heroes who assisted
             local assistTable = {}
             local allHeroes = HeroList:GetAllHeroes()
@@ -1411,7 +1423,7 @@ function FateGameMode:OnEntityKilled( keys )
                             ParticleManager:SetParticleControl( goldPopupFx, 0, killedUnit:GetAbsOrigin())
                             ParticleManager:SetParticleControl( goldPopupFx, 1, Vector(10,300,0))
                             ParticleManager:SetParticleControl( goldPopupFx, 2, Vector(3,#tostring(bounty)+1, 0))
-                            ParticleManager:SetParticleControl( goldPopupFx, 3, Vector(255, 200, 33))                            
+                            ParticleManager:SetParticleControl( goldPopupFx, 3, Vector(255, 200, 33))
                         end
                     end
                 end
@@ -1446,7 +1458,7 @@ function FateGameMode:OnEntityKilled( keys )
 
 
         end
-        
+
         -- Need condition check for GH
         --if killedUnit:GetName() == "npc_dota_hero_doom_bringer" and killedUnit:GetPlayerOwner().IsGodHandAcquired then
 
@@ -1458,19 +1470,19 @@ function FateGameMode:OnEntityKilled( keys )
                 GameRules:SetGameWinner( killerEntity:GetTeam() )
             end
         elseif _G.GameMap == "fate_elim_6v6" then
-            if killedUnit:GetTeam() == DOTA_TEAM_GOODGUYS and killedUnit:IsRealHero() then 
+            if killedUnit:GetTeam() == DOTA_TEAM_GOODGUYS and killedUnit:IsRealHero() then
                 self.nRadiantDead = self.nRadiantDead + 1
-            else 
+            else
                 self.nDireDead = self.nDireDead + 1
             end
-            
+
             local nRadiantAlive = 0
             local nDireAlive = 0
             self:LoopOverPlayers(function(player, playerID, playerHero)
                 if playerHero:IsAlive() then
                     if playerHero:GetTeam() == DOTA_TEAM_GOODGUYS then
                         nRadiantAlive = nRadiantAlive + 1
-                    else 
+                    else
                         nDireAlive = nDireAlive + 1
                     end
                 end
@@ -1486,7 +1498,7 @@ function FateGameMode:OnEntityKilled( keys )
                     Timers:RemoveTimer('timeoutmsg')
                     Timers:RemoveTimer('presence_alert')
                     self:FinishRound(false, 1)
-                elseif nDireAlive == 0 then 
+                elseif nDireAlive == 0 then
                     --print("All Dire heroes eliminated, removing existing timers and declaring winner...")
                     Timers:RemoveTimer('round_timer')
                     Timers:RemoveTimer('alertmsg')
@@ -1530,8 +1542,8 @@ function OnServantCustomizeActivated(Index, keys)
     local caster = EntIndexToHScript(keys.unitEntIndex)
     local ability = EntIndexToHScript(keys.abilEntIndex)
     local hero = caster:GetPlayerOwner():GetAssignedHero()
-    if ability:GetBehavior() ~= 6293508 then 
-        return 
+    if ability:GetBehavior() ~= 6293508 then
+        return
     end
     if ability:GetManaCost(1) > caster:GetMana() then
         SendErrorMessage(hero:GetPlayerOwnerID(), "#Not_Enough_Master_Mana")
@@ -1540,14 +1552,14 @@ function OnServantCustomizeActivated(Index, keys)
     if ability:IsCooldownReady() == false then
         return
     end
-    caster:CastAbilityImmediately(ability, caster:GetPlayerOwnerID()) 
+    caster:CastAbilityImmediately(ability, caster:GetPlayerOwnerID())
     local statTable = CreateTemporaryStatTable(hero)
     CustomGameEventManager:Send_ServerToPlayer( hero:GetPlayerOwner(), "servant_stats_updated", statTable ) -- Send the current stat info to JS
 
     hero:EmitSound("Item.DropGemWorld")
     local tomeFx = ParticleManager:CreateParticle("particles/units/heroes/hero_silencer/silencer_global_silence_sparks.vpcf", PATTACH_ABSORIGIN_FOLLOW, hero)
     ParticleManager:SetParticleControl(tomeFx, 1, hero:GetAbsOrigin())
-    
+
     --EmitSoundOnLocationForAllies(hero:GetAbsOrigin(), "Item.PickUpGemShop", hero)
 
     --ability:StartCooldown(ability:GetCooldown(1))
@@ -1605,7 +1617,7 @@ function FateGameMode:InitGameMode()
     if _G.GameMap == "fate_elim_6v6" then
         GameRules:SetCustomGameTeamMaxPlayers( DOTA_TEAM_GOODGUYS, 6)
         GameRules:SetCustomGameTeamMaxPlayers( DOTA_TEAM_BADGUYS, 6)
-        GameRules:SetHeroRespawnEnabled(false) 
+        GameRules:SetHeroRespawnEnabled(false)
         GameRules:SetGoldPerTick(0)
 
     elseif _G.GameMap == "fate_trio_rumble_3v3v3v3" then
@@ -1629,7 +1641,7 @@ function FateGameMode:InitGameMode()
         GameRules:SetGoldPerTick(7.5)
     end
     -- Set game rules
-    GameRules:SetUseUniversalShopMode(true) 
+    GameRules:SetUseUniversalShopMode(true)
     GameRules:SetSameHeroSelectionEnabled(false)
     GameRules:SetHeroSelectionTime(0)
     GameRules:SetPreGameTime(60)
@@ -1642,8 +1654,8 @@ function FateGameMode:InitGameMode()
 
     -- Random seed for RNG
     local timeTxt = string.gsub(string.gsub(GetSystemTime(), ':', ''), '0','')
-    math.randomseed(tonumber(timeTxt)) 
-    
+    math.randomseed(tonumber(timeTxt))
+
     -- Event Hooks
     ListenToGameEvent('dota_player_gained_level', Dynamic_Wrap(FateGameMode, 'OnPlayerLevelUp'), self)
     --ListenToGameEvent('dota_ability_channel_finished', Dynamic_Wrap(FateGameMode, 'OnAbilityChannelFinished'), self)
@@ -1676,7 +1688,7 @@ function FateGameMode:InitGameMode()
     --ListenToGameEvent('dota_combatlog', Dynamic_Wrap(FateGameMode, 'OnCombatLogEvent'), self)
     --ListenToGameEvent('dota_player_killed', Dynamic_Wrap(FateGameMode, 'OnPlayerKilled'), self)
     --ListenToGameEvent('player_team', Dynamic_Wrap(FateGameMode, 'OnPlayerTeam'), self)
-    
+
     -- For models swapping
     ListenToGameEvent( 'npc_spawned', Dynamic_Wrap( FateGameMode, 'OnHeroSpawned' ), self )
     -- Listen to vote result
@@ -1687,17 +1699,18 @@ function FateGameMode:InitGameMode()
     CustomGameEventManager:RegisterListener( "config_option_1_checked", OnConfig1Checked )
     CustomGameEventManager:RegisterListener( "config_option_2_checked", OnConfig2Checked )
     CustomGameEventManager:RegisterListener( "config_option_4_checked", OnConfig4Checked )
-    CustomGameEventManager:RegisterListener( "player_chat_panorama", OnPlayerChat )
+    -- CustomGameEventManager:RegisterListener( "player_chat_panorama", OnPlayerChat )
+    CustomGameEventManager:RegisterListener( "player_alt_click", OnPlayerAltClick )
     -- LUA modifiers
     LinkLuaModifier("modifier_ms_cap", "modifiers/modifier_ms_cap", LUA_MODIFIER_MOTION_NONE)
 
-    
+
     -- Commands can be registered for debugging purposes or as functions that can be called by the custom Scaleform UI
     Convars:RegisterCommand( "command_example", Dynamic_Wrap(FateGameMode, 'ExampleConsoleCommand'), "A console command example", 0 )
     function FateGameMode:ExampleConsoleCommand()
     end
-    
-    --[[-- Convars:RegisterCommand( "player_say", Dynamic_Wrap(FateGameMode, 'PlayerSay'), "Reads player chat", 0) 
+
+    --[[-- Convars:RegisterCommand( "player_say", Dynamic_Wrap(FateGameMode, 'PlayerSay'), "Reads player chat", 0)
     Convars:RegisterCommand('player_say', function(...)
         local arg = {...}
         table.remove(arg,1)
@@ -1705,35 +1718,35 @@ function FateGameMode:InitGameMode()
         keys = {}
         keys.ply = cmdPlayer
         keys.text = table.concat(arg, " ")
-        self:PlayerSay(keys) 
+        self:PlayerSay(keys)
     end, "Player said something", 0)]]
-    
+
     -- Initialized tables for tracking state
     self.nRadiantScore = 0
     self.nDireScore = 0
-    
+
     self.nCurrentRound = 0
     self.nRadiantDead = 0
     self.nDireDead = 0
     self.nLastKilled = nil
     self.fRoundStartTime = 0
-    
+
     self.bIsCasualtyOccured = false
-    
+
     -- userID map
     self.vUserNames = {}
     self.vPlayerList = {}
     self.vSteamIds = {}
     self.vBots = {}
     self.vBroadcasters = {}
-    
+
     self.vPlayers = {}
     self.vRadiant = {}
     self.vDire = {}
-    
+
     self.vPlayerShield = {}
     --IsFirstSeal = {}
-    
+
     self.bSeenWaitForPlayers = false
     -- Active Hero Map
     self.vPlayerHeroData = {}
@@ -1743,14 +1756,14 @@ end
 function CountdownTimer()
     nCountdown = nCountdown + 1
     local t = nCountdown
-    
+
     local minutes = math.floor(t / 60)
     local seconds = t - (minutes * 60)
     local m10 = math.floor(minutes / 10)
     local m01 = minutes - (m10 * 10)
     local s10 = math.floor(seconds / 10)
     local s01 = seconds - (s10 * 10)
-    local broadcast_gametimer = 
+    local broadcast_gametimer =
         {
             timer_minute_10 = m10,
             timer_minute_01 = m01,
@@ -1824,7 +1837,7 @@ function FateGameMode:TakeDamageFilter(filterTable)
         if not attacker:IsRealHero() and inflictor then
             attacker = PlayerResource:GetSelectedHeroEntity(attacker:GetPlayerID())
         elseif attacker:IsRealHero() and inflictor then
-            if inflictor:GetName() == "archer_5th_ubw" then 
+            if inflictor:GetName() == "archer_5th_ubw" then
                 return true
             end
         end
@@ -1834,7 +1847,7 @@ function FateGameMode:TakeDamageFilter(filterTable)
         local multiplier = vergHandle:GetLevelSpecialValueFor("multiplier", vergHandle:GetLevel()-1)
         if victim.IsDIAcquired then multiplier = multiplier + 25 end
         local returnDamage = damage * multiplier / 100
-        if attacker:IsMagicImmune() then 
+        if attacker:IsMagicImmune() then
             returnDamage = returnDamage * (100 - attacker:GetMagicalArmorValue())/100
             DoDamage(victim, attacker, returnDamage, DAMAGE_TYPE_PURE, {DOTA_DAMAGE_FLAG_BYPASSES_INVULNERABILITY, DOTA_DAMAGE_FLAG_BYPASSES_MAGIC_IMMUNITY}, vergHandle, false)
         else
@@ -1854,7 +1867,7 @@ end
 
 function FateGameMode:ExecuteOrderFilter(filterTable)
     local ability = EntIndexToHScript(filterTable.entindex_ability) -- the handle of item
-    local target = EntIndexToHScript(filterTable.entindex_target) 
+    local target = EntIndexToHScript(filterTable.entindex_target)
     local units = filterTable.units
     local targetIndex = filterTable.entindex_target-- the inventory target
     local playerID = filterTable.issuer_player_id_const
@@ -1866,7 +1879,7 @@ function FateGameMode:ExecuteOrderFilter(filterTable)
     if units["0"] then
         caster = EntIndexToHScript(units["0"])
     end
-    -- Find items 
+    -- Find items
     -- DOTA_UNIT_ORDER_PURASE_ITEM = 16
     -- DOTA_UNIT_ORDER_SELL_ITEM = 17
     -- DOTA_UNIT_ORDER_DISASSEMBLE_ITEM = 18
@@ -1889,7 +1902,7 @@ function FateGameMode:ExecuteOrderFilter(filterTable)
     if orderType == 19 then
         local currentItemIndex, itemName = nil
         local charges = -1
-        for i=0, 11 do 
+        for i=0, 11 do
             if ability == caster:GetItemInSlot(i) then
                 currentItemIndex = i
                 itemName = ability:GetName()
@@ -1926,15 +1939,15 @@ function FateGameMode:ExecuteOrderFilter(filterTable)
                 return false
             else
                 print("Deducing extra cost" .. ability:GetCost()*0.5 .. "from player gold")
-                hero:ModifyGold(ability:GetCost() *0.5, true , 0) 
+                hero:ModifyGold(ability:GetCost() *0.5, true , 0)
             end
         -- If hero is in base, check for C scroll stock
         else
             -- If hero is in base, check for C scroll stock
             if ability:GetName() == "item_c_scroll" then
-                if caster.CStock > 0 then 
+                if caster.CStock > 0 then
                     caster.CStock = hero.CStock - 1
-                else 
+                else
                     FireGameEvent( 'custom_error_show', { player_ID = plyID, _error = "Out Of Stock" } )
                     return false
                 end
@@ -1950,7 +1963,7 @@ function FateGameMode:ExecuteOrderFilter(filterTable)
     -- What do we do when we sell items?
     elseif orderType == 17 then
         EmitSoundOnClient("General.Sell", caster:GetPlayerOwner())
-        caster:ModifyGold(GetItemCost(ability:GetName()) *0.5, true , 0) 
+        caster:ModifyGold(GetItemCost(ability:GetName()) *0.5, true , 0)
         ability:RemoveSelf()
         return false
     end
@@ -1970,26 +1983,26 @@ function FateGameMode:InitializeRound()
                 CreateUITimer("Next Holy Grail's Blessing", 599, "ten_min_timer")
                 self:LoopOverPlayers(function(player, playerID, playerHero)
                     local hero = playerHero
-                    hero.MasterUnit:SetHealth(hero.MasterUnit:GetMaxHealth()) 
-                    hero.MasterUnit:SetMana(hero.MasterUnit:GetMana()+BLESSING_MANA_REWARD) 
+                    hero.MasterUnit:SetHealth(hero.MasterUnit:GetMaxHealth())
+                    hero.MasterUnit:SetMana(hero.MasterUnit:GetMana()+BLESSING_MANA_REWARD)
                     hero.MasterUnit2:SetHealth(hero.MasterUnit2:GetMaxHealth())
                     hero.MasterUnit2:SetMana(hero.MasterUnit2:GetMana()+BLESSING_MANA_REWARD)
                     MinimapEvent( hero:GetTeamNumber(), hero, hero.MasterUnit:GetAbsOrigin().x, hero.MasterUnit2:GetAbsOrigin().y, DOTA_MINIMAP_EVENT_HINT_LOCATION, 2 )
                 end)
                 Notifications:TopToAll("#Fate_Timer_10minute", 5, nil, {color="rgb(255,255,255)", ["font-size"]="25px"})
-                
+
                 return BLESSING_PERIOD
         end})]]
     end
-    
+
     -- Flag game mode as pre round, and display tip
-    _G.IsPreRound = true 
+    _G.IsPreRound = true
     CreateUITimer("Pre-Round", PRE_ROUND_DURATION, "pregame_timer")
     --FireGameEvent('cgm_timer_display', { timerMsg = "Pre-Round", timerSeconds = 16, timerEnd = true, timerPosition = 0})
     DisplayTip()
-    Say(nil, string.format("Round %d will begin in " .. PRE_ROUND_DURATION .. " seconds.", self.nCurrentRound), false) 
-    
-    
+    Say(nil, string.format("Round %d will begin in " .. PRE_ROUND_DURATION .. " seconds.", self.nCurrentRound), false)
+
+
     local msg = {
         message = "Round " .. self.nCurrentRound .. " has begun!",
         duration = 4.0
@@ -2006,34 +2019,34 @@ function FateGameMode:InitializeRound()
         message = "#Fate_Timer_Timeout",
         duration = 4.0
     }
-    
+
     -- Set up heroes for new round
     self:LoopOverPlayers(function(ply, plyID, playerHero)
         local hero = playerHero
-        
+
         ResetAbilities(hero)
         giveUnitDataDrivenModifier(hero, hero, "round_pause", PRE_ROUND_DURATION) -- Pause all heroes
-        hero:SetGold(0, false) 
+        hero:SetGold(0, false)
         hero.CStock = 10
-        
-        -- Grant gold 
-        if hero:GetGold() < 5000 then -- 
+
+        -- Grant gold
+        if hero:GetGold() < 5000 then --
             --print("[FateGameMode] " .. hero:GetName() .. " gained 3000 gold at the start of round")
             if hero.AvariceCount ~= nil then
-                hero:ModifyGold(3000 + hero.AvariceCount * 1500, true, 0) 
+                hero:ModifyGold(3000 + hero.AvariceCount * 1500, true, 0)
             else
-                hero:ModifyGold(3000, true, 0) 
+                hero:ModifyGold(3000, true, 0)
             end
         end
-        
-        if self.nCurrentRound ~= 1 then 
+
+        if self.nCurrentRound ~= 1 then
             local multiplier = (0.5+0.01*(hero:GetDeaths()-hero:GetKills()))
             --print("[FateGameMode]" .. hero:GetName() .. " of player " .. hero:GetPlayerID() .. " gained " .. (_G.XP_PER_LEVEL_TABLE[hero:GetLevel()] * multiplier) .. " experience at the start of round")
-            hero:AddExperience(_G.XP_PER_LEVEL_TABLE[hero:GetLevel()] * multiplier , false, false) 
+            hero:AddExperience(_G.XP_PER_LEVEL_TABLE[hero:GetLevel()] * multiplier , false, false)
         end
     end)
-    
-    
+
+
     Timers:CreateTimer('beginround', {
         endTime = PRE_ROUND_DURATION,
         callback = function()
@@ -2044,36 +2057,36 @@ function FateGameMode:InitializeRound()
             CreateUITimer(("Round " .. self.nCurrentRound), ROUND_DURATION, "round_timer" .. self.nCurrentRound)
             --FireGameEvent('cgm_timer_display', { timerMsg = ("Round " .. self.nCurrentRound), timerSeconds = 151, timerEnd = true, timerPosition = 0})
             --roundQuest = StartQuestTimer("roundTimerQuest", "Round " .. self.nCurrentRound, 150)
-            
+
             self:LoopOverPlayers(function(player, playerID, playerHero)
                 playerHero:RemoveModifierByName("round_pause")
             end)
-            
+
             FireGameEvent("show_center_message",msg)
         end
     })
-    
+
     Timers:CreateTimer('presence_alert', {
         endTime = PRESENCE_ALERT_DURATION + PRE_ROUND_DURATION,
         callback = function()
-            GameRules:SendCustomMessage("#Fate_Presence_Alert", 0, 0) 
+            GameRules:SendCustomMessage("#Fate_Presence_Alert", 0, 0)
         end
     })
-    
+
     Timers:CreateTimer('round_30sec_alert', {
         endTime = PRE_ROUND_DURATION + ROUND_DURATION - 30,
         callback = function()
             FireGameEvent("show_center_message",alertmsg)
         end
     })
-    
+
     Timers:CreateTimer('round_10sec_alert', {
         endTime = PRE_ROUND_DURATION + ROUND_DURATION - 10,
         callback = function()
             FireGameEvent("show_center_message",alertmsg2)
         end
     })
-    
+
     Timers:CreateTimer('round_timer', {
         endTime = PRE_ROUND_DURATION + ROUND_DURATION,
         callback = function()
@@ -2083,10 +2096,10 @@ function FateGameMode:InitializeRound()
             local nDireAlive = 0
             -- Check how many people are alive in each team
             self:LoopOverPlayers(function(player, playerID, playerHero)
-                if playerHero:IsAlive() then 
+                if playerHero:IsAlive() then
                     if playerHero:GetTeam() == DOTA_TEAM_GOODGUYS then
                         nRadiantAlive = nRadiantAlive + 1
-                    else 
+                    else
                         nDireAlive = nDireAlive + 1
                     end
                 elseif playerHero:GetName() == "npc_dota_hero_mirana" and playerHero.bIsLaPucelleActivatedThisRound then
@@ -2094,7 +2107,7 @@ function FateGameMode:InitializeRound()
                     playerHero.bIsLaPucelleActivatedThisRound = false
                     if playerHero:GetTeam() == DOTA_TEAM_GOODGUYS then
                         nRadiantAlive = nRadiantAlive + 1
-                    else 
+                    else
                         nDireAlive = nDireAlive + 1
                     end
                 end
@@ -2105,10 +2118,10 @@ function FateGameMode:InitializeRound()
             -- if remaining players are equal
             if nRadiantAlive == nDireAlive then
                 -- Default Radiant Win
-                if self.nRadiantScore < self.nDireScore then 
+                if self.nRadiantScore < self.nDireScore then
                     self:FinishRound(true,3)
                 -- Default Dire Win
-                elseif self.nRadiantScore > self.nDireScore then 
+                elseif self.nRadiantScore > self.nDireScore then
                     self:FinishRound(true,4)
                 -- Draw
                 elseif self.nRadiantScore == self.nDireScore then
@@ -2124,10 +2137,10 @@ function FateGameMode:InitializeRound()
     })
 end
 
---[[ 
-0 : Radiant 
-1 : Dire 
-2 : Draw 
+--[[
+0 : Radiant
+1 : Dire
+2 : Draw
 3 : Radiant(by default)
 4 : Dire(by default)]]
 function FateGameMode:FinishRound(IsTimeOut, winner)
@@ -2182,9 +2195,9 @@ function FateGameMode:FinishRound(IsTimeOut, winner)
     end
 
     -- decide the winner
-    if winner == 0 then 
+    if winner == 0 then
         GameRules:SendCustomMessage("#Fate_Round_Winner_1", 0, 0)
-        self.nRadiantScore = self.nRadiantScore + 1 
+        self.nRadiantScore = self.nRadiantScore + 1
         winnerEventData.winnerTeam = 0
         GameRules.Winner = 2
         statCollection:submitRound(false)
@@ -2225,12 +2238,12 @@ function FateGameMode:FinishRound(IsTimeOut, winner)
             --print("granted 1 mana to " .. pHero:GetName())
         end
     end)
-    -- Set score 
+    -- Set score
     mode = GameRules:GetGameModeEntity()
     mode:SetTopBarTeamValue ( DOTA_TEAM_BADGUYS, self.nDireScore )
     mode:SetTopBarTeamValue ( DOTA_TEAM_GOODGUYS, self.nRadiantScore )
     self.nCurrentRound = self.nCurrentRound + 1
-    
+
     -- check for win condition
     if self.nRadiantScore == VICTORY_CONDITION then
         Say(nil, "Radiant Victory!", false)
@@ -2243,7 +2256,7 @@ function FateGameMode:FinishRound(IsTimeOut, winner)
         GameRules:SetGameWinner( DOTA_TEAM_BADGUYS )
         return
     end
-    
+
     Timers:CreateTimer('roundend', {
         endTime = 5,
         callback = function()
@@ -2283,25 +2296,25 @@ function FateGameMode:FinishRound(IsTimeOut, winner)
                 end]]
 
                 --[[if RADIANT then
-                    check if RADIANT team 
-                        if round = 0 or 1, 
+                    check if RADIANT team
+                        if round = 0 or 1,
                         if odd rounds, set spawn location to RADIANT
                         else DIRE
                     end
                 --]]
                 if pHero:GetTeam() == 2 then
                     if self.nCurrentRound == 0 or self.nCurrentRound == 1 then -- if round = 0 or 1, do not change anything
-                        
+
                     elseif self.nCurrentRound % 2 == 0 then -- if even rounds, set spawn to DIRE
-                        pHero.RespawnPos = SPAWN_POSITION_DIRE_DM 
+                        pHero.RespawnPos = SPAWN_POSITION_DIRE_DM
                     else
                         pHero.RespawnPos = SPAWN_POSITION_RADIANT_DM
                     end
                 elseif pHero:GetTeam() == 3 then
                     if self.nCurrentRound == 0 or self.nCurrentRound == 1 then -- if round = 0 or 1, do not change anything
-                        
+
                     elseif self.nCurrentRound % 2 == 0 then -- if even rounds, set spawn to RADIANT
-                        pHero.RespawnPos = SPAWN_POSITION_RADIANT_DM 
+                        pHero.RespawnPos = SPAWN_POSITION_RADIANT_DM
                     else
                         pHero.RespawnPos = SPAWN_POSITION_DIRE_DM
                     end
@@ -2317,7 +2330,7 @@ function FateGameMode:FinishRound(IsTimeOut, winner)
             _G.CurrentGameState = "FATE_PRE_ROUND"
         end
     })
-    
+
 end
 
 function FateGameMode:LoopOverPlayers(callback)
@@ -2330,7 +2343,7 @@ function FateGameMode:LoopOverPlayers(callback)
             if callback(player, playerID, playerHero) then
                 break
             end
-        end 
+        end
     end
 end
 
@@ -2339,7 +2352,7 @@ function FateGameMode:CaptureGameMode()
     print("First player loaded in, setting parameters")
     if mode == nil then
         -- Set FateGameMode parameters
-        mode = GameRules:GetGameModeEntity() 
+        mode = GameRules:GetGameModeEntity()
 
 
         --mode:SetCameraDistanceOverride(1600)
@@ -2364,17 +2377,17 @@ function FateGameMode:CaptureGameMode()
 
         if _G.GameMap == "fate_elim_6v6" then
             mode:SetTopBarTeamValuesOverride ( USE_CUSTOM_TOP_BAR_VALUES )
-        end        
-    end 
+        end
+    end
 end
 
 
--- This function is called 1 to 2 times as the player connects initially but before they 
+-- This function is called 1 to 2 times as the player connects initially but before they
 -- have completely connected
 function FateGameMode:PlayerConnect(keys)
     --print('[BAREBONES] PlayerConnect')
     --PrintTable(keys)
-    
+
     if keys.bot == 1 then
         -- This user is a Bot, so add it to the bots table
         self.vBots[keys.userid] = 1
@@ -2382,12 +2395,12 @@ function FateGameMode:PlayerConnect(keys)
 end
 
 -- This function is called once when the player fully connects and becomes "Ready" during Loading
--- Assign players 
+-- Assign players
 function FateGameMode:OnConnectFull(keys)
     --print ('[BAREBONES] OnConnectFull')
     --PrintTable(keys)
     FateGameMode:CaptureGameMode()
-    
+
     local entIndex = keys.index+1
     -- The Player entity of the joining user
     local ply = EntIndexToHScript(entIndex)
@@ -2401,7 +2414,7 @@ function FateGameMode:OnConnectFull(keys)
         print("teams not assigned yet, using index as player ID = " .. playerID)
     end
     self.vPlayerList = self.vPlayerList or {}
-    self.vPlayerList[keys.userid] = playerID 
+    self.vPlayerList[keys.userid] = playerID
     SendChatToPanorama("player " .. playerID .. " got assigned to " .. keys.userid .. "index in player list")
     --print(self.vPlayerList[keys.userid])]]
 end


### PR DESCRIPTION
Alt-clicking UI Timers will now show the Timer message and remaining time left on the timer.

For example, `Unlimited Blade Works ▶ 00:00:03`.

Each player has a cooldown of 1 second on these messages.

**Important**: ~~Since we have to allow clicking on the timer panels, they will not obstruct clicks. Given that the timers do take up a bit of space on the top of the UI, will this be an issue? Perhaps changing the alt-click to be on the timer name instead of the whole timer panel might be feasible.~~ Looks like you can't click through the panels currently.

**Other issues**: Localisation is not taken into account.

If this works properly in the test version, Alt-Click functionality could be implemented for other UI features as well, such as Hero pictures (alive or dead) or current gold.
