### PR TITLE
Several small bug fixes

### DIFF
--- a/game/dota_addons/fateanother/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/fateanother/scripts/npc/npc_abilities_custom.txt
@@ -143,7 +143,7 @@
 			"04"
 			{
 				"var_type"				"FIELD_FLOAT"
-				"cooldown"				"45"
+				"cooldown"				"35"
 			}
 		}
 		

--- a/game/dota_addons/fateanother/scripts/npc/npc_items_custom.txt
+++ b/game/dota_addons/fateanother/scripts/npc/npc_items_custom.txt
@@ -1667,22 +1667,6 @@
 		}
 	    "OnSpellStart"
 	    {
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_purge"
-	    		"Target"			"TARGET"
-	    	}
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_slow_tier1"
-	    		"Target"			"TARGET"
-	    	}
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_slow_tier2"
-	    		"Target"			"TARGET"
-	    	}
-	    		    		
 	    	"RunScript"
 			{
 				"ScriptFile"	"items"
@@ -1811,22 +1795,6 @@
 		}
 	    "OnSpellStart"
 	    {
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_purge"
-	    		"Target"			"TARGET"
-	    	}
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_slow_tier1"
-	    		"Target"			"TARGET"
-	    	}
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_slow_tier2"
-	    		"Target"			"TARGET"
-	    	}
-	    		    		
 	    	"RunScript"
 			{
 				"ScriptFile"	"items"

--- a/game/dota_addons/fateanother/scripts/npc/npc_items_custom.txt
+++ b/game/dota_addons/fateanother/scripts/npc/npc_items_custom.txt
@@ -502,29 +502,16 @@
 	    "OnSpellStart"
 	    {
 	    	"SpendCharge" {}
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"	"item_pot_regen"
-	    		"Target"
-				{
-					"Center"	"CASTER"
-					"Flags"		"DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-				}
-	    	}
-			"FireSound"
+	    	"RunScript"
 			{
-				"EffectName"	"DOTA_Item.ClarityPotion.Activate"
-	    		"Target"
-				{
-					"Center"	"CASTER"
-					"Flags"		"DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-				}
+				"ScriptFile"	"items"
+				"Function"		"ManaEssence"
 			}
 	    }
 	    "Modifiers"
 	    {
 	        "item_pot_regen"
-	        {	
+	        {
 	        	"Attributes"	"MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
 	        	"Duration"		"10.0"
 	        	"EffectName"	"particles/items_fx/healing_flask.vpcf"
@@ -732,24 +719,11 @@
 	    "OnSpellStart"
 	    {
 	    	"SpendCharge" {}
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"	"modifier_speed_gem"
-	    		"Target"
-				{
-					"Center"	"CASTER"
-					"Flags"		"DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-				}
-	    	}
-	    	"FireSound"
-	    	{
-	    		"EffectName"		"DOTA_Item.PhaseBoots.Activate"
-	    		"Target"
-				{
-					"Center"	"CASTER"
-					"Flags"		"DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-				}
-	    	}
+	    	"RunScript"
+			{
+				"ScriptFile"	"items"
+				"Function"		"SpeedGem"
+			}
 	    }
 	    "Modifiers"
 	    {
@@ -885,24 +859,11 @@
 		}
 	    "OnSpellStart"
 	    {
-	    	"ApplyModifier"
-	    	{
-	    		"ModifierName"		"modifier_berserk_scroll"
-	    		"Target"
-				{
-					"Center"	"CASTER"
-					"Flags"		"DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-				}
-	    	}
-	    	"FireSound"
-	    	{
-	    		"EffectName"		"DOTA_Item.MaskOfMadness.Activate"
-	    		"Target"
-				{
-					"Center"	"CASTER"
-					"Flags"		"DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
-				}
-	    	}
+	    	"RunScript"
+			{
+				"ScriptFile"	"items"
+				"Function"		"BerserkScroll"
+			}
 	    	"SpendCharge" {}
 	    }
 	    "Modifiers"

--- a/game/dota_addons/fateanother/scripts/vscripts/astolfo_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/astolfo_ability.lua
@@ -40,7 +40,6 @@ function OnVanishStart(keys)
 		caster:GiveMana(ability:GetManaCost(1)) 
 		return 
 	end 
-	if IsSpellBlocked(keys.target) then return end -- Linken effect checker
 	local info = {
 		Target = target, -- chainTarget
 		Source = caster, -- chainSource
@@ -55,8 +54,13 @@ function OnVanishStart(keys)
 end
 
 function OnVanishHit(keys)
-	local caster = keys.caster
 	local target = keys.target
+	if IsSpellBlocked(target)
+		or target:IsMagicImmune()
+	then
+		return
+	end -- Linken effect checker
+	local caster = keys.caster
 	local ability = keys.ability
 	local damage = keys.Damage
 	ApplyPurge(target)

--- a/game/dota_addons/fateanother/scripts/vscripts/items.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/items.lua
@@ -483,7 +483,7 @@ function ManaEssence(keys)
 		RefundItem(caster, ability)
 		return
 	end
-	ability:ApplyDataDrivenModifier(caster, caster, "modifier_pot_regen", {})
+	ability:ApplyDataDrivenModifier(caster, caster, "item_pot_regen", {})
 	caster:EmitSound("DOTA_Item.ClarityPotion.Activate")
 end
 

--- a/game/dota_addons/fateanother/scripts/vscripts/items.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/items.lua
@@ -476,6 +476,39 @@ function StashBlink(keys)
 	FindClearSpaceForUnit(caster, caster:GetAbsOrigin(), true)
 end
 
+function ManaEssence(keys)
+	local caster = keys.caster
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
+	ability:ApplyDataDrivenModifier(caster, caster, "modifier_pot_regen", {})
+	caster:EmitSound("DOTA_Item.ClarityPotion.Activate")
+end
+
+function BerserkScroll(keys)
+	local caster = keys.caster
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
+	ability:ApplyDataDrivenModifier(caster, caster, "modifier_berserk_scroll", {})
+	caster:EmitSound("DOTA_Item.MaskOfMadness.Activate")
+end
+
+function SpeedGem(keys)
+	local caster = keys.caster
+	local ability = keys.ability
+	if caster:HasModifier("jump_pause_nosilence") then
+		RefundItem(caster, ability)
+		return
+	end
+	ability:ApplyDataDrivenModifier(caster, caster, "modifier_speed_gem", {})
+	caster:EmitSound("DOTA_Item.PhaseBoots.Activate")
+end
+
 function CScroll(keys)
 	local caster = keys.caster
 	local ability = keys.ability

--- a/game/dota_addons/fateanother/scripts/vscripts/items.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/items.lua
@@ -166,6 +166,8 @@ end
 function RefundItem(caster, item)
 	local charges = item:GetCurrentCharges()
 	if charges == 0 then
+		-- if the item has zero charges, it is removed from
+		-- the inventory, therefore we have to recreate the item
 		local itemName = item:GetAbilityName()
 		item = CreateItem(itemName, caster, nil)
 		item:SetCurrentCharges(1)

--- a/game/dota_addons/fateanother/scripts/vscripts/items.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/items.lua
@@ -561,6 +561,11 @@ function SScroll(keys)
 
 	DoDamage(caster, target, 400, DAMAGE_TYPE_MAGICAL, 0, ability, false)
 	ApplyPurge(target)
+
+	ability:ApplyDataDrivenModifier(caster, target, "modifier_purge", {})
+	ability:ApplyDataDrivenModifier(caster, target, "modifier_slow_tier1", {})
+	ability:ApplyDataDrivenModifier(caster, target, "modifier_slow_tier2", {})
+
 	local boltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster)
 	ParticleManager:SetParticleControl(boltFx, 1, Vector(target:GetAbsOrigin().x,target:GetAbsOrigin().y,target:GetAbsOrigin().z+((target:GetBoundingMaxs().z - target:GetBoundingMins().z)/2)))
 
@@ -595,6 +600,10 @@ function EXScroll(keys)
 	}
 	DoDamage(caster, target, 600, DAMAGE_TYPE_MAGICAL, 0, ability, false)
 	ApplyPurge(target)
+
+	ability:ApplyDataDrivenModifier(caster, target, "modifier_purge", {})
+	ability:ApplyDataDrivenModifier(caster, target, "modifier_slow_tier1", {})
+	ability:ApplyDataDrivenModifier(caster, target, "modifier_slow_tier2", {})
 
 	local boltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_zuus/zuus_arc_lightning.vpcf", PATTACH_OVERHEAD_FOLLOW, caster)
 	--local lightningBoltFx = ParticleManager:CreateParticle("particles/units/heroes/hero_leshrac/leshrac_lightning_bolt.vpcf", PATTACH_ABSORIGIN, target)

--- a/game/dota_addons/fateanother/scripts/vscripts/lancer_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/lancer_ability.lua
@@ -25,7 +25,7 @@ function LancerOnTakeDamage(keys)
 	if currentHealth == 0 and keys.ability:IsCooldownReady() and keys.DamageTaken <= highend and keys.DamageTaken >= lowend and IsRevivePossible(caster) then
 		caster:SetHealth(health)
 		keys.ability:StartCooldown(cd) 
-		ability:ApplyDataDrivenModifier(caster, caster, "modifier_battle_continuation_cooldown", {duration = ability:GetCooldown(ability:GetLevel())})
+		ability:ApplyDataDrivenModifier(caster, caster, "modifier_battle_continuation_cooldown", {duration = cd})
 		local reviveFx = ParticleManager:CreateParticle("particles/items_fx/aegis_respawn.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
 		ParticleManager:SetParticleControl(reviveFx, 3, caster:GetAbsOrigin())
 

--- a/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
@@ -830,14 +830,14 @@ function IsSpellBlocked(target)
     elseif target:HasModifier("modifier_wind_protection_passive") then
         if math.random(100) < 15 then
             EmitSoundWithCooldown("DOTA_Item.LinkensSphere.Activate", target, 1)
-            ParticleManager:CreateParticle("particles/items_fx/immunity_sphere.vpcf", PATTACH_ABSORIGIN, target)
-            ParticleManager:SetParticleControl(particle, 0, target:GetAbsOrigin()) 
-            return true 
+            local particle = ParticleManager:CreateParticle("particles/items_fx/immunity_sphere.vpcf", PATTACH_ABSORIGIN, target)
+            ParticleManager:SetParticleControl(particle, 0, target:GetAbsOrigin())
+            return true
         end
-    else 
+    else
         return false
     end
-end 
+end
 
 function EmitSoundWithCooldown(soundname, target, cooldown)
     if not target.bIsSoundOnCooldown then

--- a/game/dota_addons/fateanother/scripts/vscripts/saber_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/saber_ability.lua
@@ -59,12 +59,16 @@ function CreateWind(keys)
 end
 
 function InvisibleAirPull(keys)
-	if IsSpellBlocked(keys.target) then return end -- Linken effect checker
-	if keys.target:GetName() == "npc_dota_hero_bounty_hunter" and keys.target.IsPFWAcquired then return end -- Protection from Wind checker
+	local target = keys.target
+	if IsSpellBlocked(target) -- Linken's
+		or target:IsMagicImmune() -- Magic immunity
+		or target:GetName() == "npc_dota_hero_bounty_hunter" and target.IsPFWAcquired -- Protection from Wind
+	then
+		return
+	end
 
 	keys.caster.invisible_air_reach_target = true					-- Addition
 	local caster = keys.caster
-	local target = keys.target
 	local ability = keys.ability
 	local ply = caster:GetPlayerOwner()
 

--- a/game/dota_addons/fateanother/scripts/vscripts/tamamo_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/tamamo_ability.lua
@@ -558,7 +558,7 @@ function OnShackleThink(keys)
 	local ability = keys.ability
 	local target = keys.target
 	local dist = (caster:GetAbsOrigin() - target:GetAbsOrigin()):Length2D()
-	if dist > 2500 then
+	if dist > 2500 or target:IsMagicImmune() then
 		target:RemoveModifierByName("modifier_mystic_shackle")
 	elseif dist > 700 then
 		local diff = target:GetAbsOrigin() - caster:GetAbsOrigin()


### PR DESCRIPTION
- [x] Fix #85 and remaining items for #79. 
  - [x] S Scroll
  - [x] EX Scroll
  - [ ] Berserk Scroll (need to check EmitSound)
  - [ ] Speed Gem (need to check EmitSound)
  - [ ] Mana Essence (need to check EmitSound)
  - All items should now use `RunScript` to apply modifiers
- [x] Fix TA's Protection From Wind setting invalid particle when triggered
- [x]  Fix #84
  - [x] Tamamo's Shackle - modifier is removed when target becomes magic immune
  - [x] Saber's Invisible Air
  - [x] Black Rider's Vanish - also moved SpellBlock check to on projectile hit instead of on cast
- [x] Fix #80
- [x] Fix Saber's Instinct cooldown indicator having wrong duration