### PR TITLE
C scroll stock and increased item price when out of base overhaul

### DIFF
--- a/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
@@ -652,21 +652,6 @@ function FateGameMode:OnPlayerChat(keys)
         CustomGameEventManager:Send_ServerToPlayer( ply, "player_bgm_off", {} )
     end
 
-    if text == "-savestash" then
-        local hero = ply:GetAssignedHero()
-        SaveStashState(hero)
-    end
-
-    if text == "-loadstash" then
-        local hero = ply:GetAssignedHero()
-        LoadStashState(hero)
-    end
-
-    if text == "-cscroll" then
-        local hero = ply:GetAssignedHero()
-        hero.CStock = 10
-    end
-
     -- Sends a message to request gold
     local pID, goldAmt = string.match(text, "^-(%d%d?) (%d+)")
     if pID ~= nil and goldAmt ~= nil then
@@ -1150,9 +1135,6 @@ function FateGameMode:OnItemPurchased( keys )
                 LoadStashState(hero)
             else
                 local itemsWithSameName = Entities:FindAllByName(itemName)
-                for i,k in ipairs(itemsWithSameName) do
-                    DeepPrintTable(k)
-                end
                 local droppedItem
                 local purchasedTime = -9999 
                 for i = 1,#itemsWithSameName do
@@ -1163,9 +1145,8 @@ function FateGameMode:OnItemPurchased( keys )
                     end
                 end
 
-                print(purchasedTime)
                 if droppedItem == nil then
-                    print("Item was nil: " .. itemName)
+                    print("Unexpected: Item was nil - " .. itemName)
                 else
                     droppedItem:GetContainer():RemoveSelf()
                     droppedItem:RemoveSelf()

--- a/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
@@ -652,6 +652,16 @@ function FateGameMode:OnPlayerChat(keys)
         CustomGameEventManager:Send_ServerToPlayer( ply, "player_bgm_off", {} )
     end
 
+    if text == "-savestash" then
+        local hero = ply:GetAssignedHero()
+        SaveStashState(hero)
+    end
+
+    if text == "-loadstash" then
+        local hero = ply:GetAssignedHero()
+        LoadStashState(hero)
+    end
+
     -- Sends a message to request gold
     local pID, goldAmt = string.match(text, "^-(%d%d?) (%d+)")
     if pID ~= nil and goldAmt ~= nil then
@@ -1097,7 +1107,6 @@ function FateGameMode:OnItemPurchased( keys )
     CheckItemCombinationInStash(hero)
 
     local oldStash = GetStashItems(hero)
-
 
 
     if hero.IsInBase == false then

--- a/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
@@ -662,6 +662,11 @@ function FateGameMode:OnPlayerChat(keys)
         LoadStashState(hero)
     end
 
+    if text == "-cscroll" then
+        local hero = ply:GetAssignedHero()
+        hero.CStock = 10
+    end
+
     -- Sends a message to request gold
     local pID, goldAmt = string.match(text, "^-(%d%d?) (%d+)")
     if pID ~= nil and goldAmt ~= nil then
@@ -1106,45 +1111,70 @@ function FateGameMode:OnItemPurchased( keys )
     local hero = PlayerResource:GetPlayer(plyID):GetAssignedHero()
     CheckItemCombinationInStash(hero)
 
-    local oldStash = GetStashItems(hero)
-
-
-    if hero.IsInBase == false then
-        if PlayerResource:GetGold(plyID) + itemCost < itemCost * 1.5 then
-            -- This will take care of non-component items
-            for i = 1, #oldStash do
-                if oldStash[i]:GetName() == itemName then
-                    SendErrorMessage(plyID, "#Not_Enough_Gold_Item")
-                    --hero:RemoveItem(oldStash[i])
-                    hero:ModifyGold(itemCost, true, 0)
-                    oldStash[i]:RemoveSelf()
-                    break
-                end
-            end
-        else
-            --print("Deducing extra cost" .. itemCost*0.5 .. "from player gold")
-            hero:ModifyGold(-itemCost*0.5, true , 0)
-        end
-        -- If hero is in base, check for C scroll stock
-    else
-        -- If hero is in base, check for C scroll stock
+    local isPriceIncreased = true
+    if hero.IsInBase then
         if itemName == "item_c_scroll" then
             if hero.CStock > 0 then
                 hero.CStock = hero.CStock - 1
-
+                isPriceIncreased = false
             else
-                for i = 1, #oldStash do
-                    if oldStash[i]:GetName() == "item_c_scroll" then
-                        SendErrorMessage(plyID, "#Out_Of_Stock_C_Scroll")
-                        --hero:RemoveItem(oldStash[i])
-                        hero:ModifyGold(itemCost, true, 0)
-                        oldStash[i]:RemoveSelf()
-                        break
+                SendErrorMessage(plyID, "#Out_Of_Stock_C_Scroll")
+            end
+        else
+            isPriceIncreased = false
+        end
+    end
+
+    if isPriceIncreased then
+        if PlayerResource:GetGold(plyID) >= itemCost * 0.5 then
+            -- account for unreliable gold
+            local unreliableGold = PlayerResource:GetUnreliableGold(plyID)
+            hero:ModifyGold(-itemCost * 0.5, false, 0)
+            local diff = math.max(itemCost * 0.5 - unreliableGold, 0)
+            hero:ModifyGold(-diff, true, 0)
+        else
+            SendErrorMessage(plyID, "#Not_Enough_Gold_Item")
+            hero:ModifyGold(itemCost, true, 0)
+            local isItemDropped = true
+
+            local stash = GetStashItems(hero)
+            local oldStash = hero.stashState or {}
+            for i = 1,6 do
+                if stash[i] ~= oldStash[i] then
+                    isItemDropped = false
+                    break
+                end
+            end
+
+            if not isItemDropped then
+                LoadStashState(hero)
+            else
+                local itemsWithSameName = Entities:FindAllByName(itemName)
+                for i,k in ipairs(itemsWithSameName) do
+                    DeepPrintTable(k)
+                end
+                local droppedItem
+                local purchasedTime = -9999 
+                for i = 1,#itemsWithSameName do
+                    local item = itemsWithSameName[i]
+                    if item:GetPurchaser() == hero and item:GetPurchaseTime() > purchasedTime then
+                        droppedItem = item
+                        purchasedTime = item:GetPurchaseTime()
                     end
+                end
+
+                print(purchasedTime)
+                if droppedItem == nil then
+                    print("Item was nil: " .. itemName)
+                else
+                    droppedItem:GetContainer():RemoveSelf()
+                    droppedItem:RemoveSelf()
                 end
             end
         end
     end
+
+    SaveStashState(hero)
 
     if PlayerResource:GetGold(plyID) < 200 and hero.bIsAutoGoldRequestOn then
         Notifications:RightToTeamGold(hero:GetTeam(), "<font color='#FF5050'>" .. FindName(hero:GetName()) .. "</font> at <font color='#FFD700'>" .. hero:GetGold() .. "g</font> is requesting gold. Type <font color='#58ACFA'>-" .. plyID .. " (goldamount)</font> to send gold!", 7, nil, {color="rgb(255,255,255)", ["font-size"]="20px"}, true)
@@ -1153,11 +1183,9 @@ end
 
 function GetStashItems(hero)
     local stashTable = {}
-    for i=6,11 do
-        local heroItem = hero:GetItemInSlot(i)
-        if heroItem ~= nil then
-            table.insert(stashTable, heroItem)
-        end
+    for i=1,6 do
+        local item = hero:GetItemInSlot(i + 5)
+        table.insert(stashTable, i, item and item:GetName())
     end
     return stashTable
 end
@@ -1923,16 +1951,19 @@ function FateGameMode:ExecuteOrderFilter(filterTable)
         if (currentItemIndex >= 0 and currentItemIndex <= 5) and (targetIndex >= 6 and targetIndex <= 11) then
             ability:RemoveSelf()
             CreateItemAtSlot(caster, itemName, targetIndex, charges, false, true)
+            SaveStashState(caster)
             return false
         -- Item is currently placed in stash, while target is in inventory
         elseif (currentItemIndex >= 6 and currentItemIndex <= 11) and (targetIndex >= 0 and targetIndex <=5) then
             ability:RemoveSelf()
             CreateItemAtSlot(caster, itemName, targetIndex, charges, true, false)
+            SaveStashState(caster)
             return false
         -- Item is currently placed in stash, and it is just being moved within there
         elseif (currentItemIndex >= 6 and currentItemIndex <= 11) and (targetIndex >= 6 and targetIndex <=11) then
             ability:RemoveSelf()
             CreateItemAtSlot(caster, itemName, targetIndex, charges, false, true)
+            SaveStashState(caster)
             return false
         end
     -- What do we do when item is bought?
@@ -1974,6 +2005,7 @@ function FateGameMode:ExecuteOrderFilter(filterTable)
         EmitSoundOnClient("General.Sell", caster:GetPlayerOwner())
         caster:ModifyGold(GetItemCost(ability:GetName()) *0.5, true , 0)
         ability:RemoveSelf()
+        SaveStashState(caster)
         return false
     end
     return true

--- a/game/dota_addons/fateanother/scripts/vscripts/caster_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/caster_ability.lua
@@ -771,6 +771,8 @@ function OnItemStart(keys)
 
 	caster:AddItem(item)
 	CheckItemCombination(caster)
+
+    SaveStashState(caster)
 end
 
 function OnArgosStart(keys)

--- a/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
@@ -1572,18 +1572,13 @@ function SaveStashState(hero)
         table.insert(stashState, i, item and item:GetName())
         table.insert(stashChargeState, i, item and item:GetCurrentCharges())
     end
-    for i=1,6 do
-        local m = (stashState[i] or "nil")
-        local m1 = (stashChargeState[i] or "nil")
-        print(m .. " " .. m1)
-    end
     hero.stashState = stashState
     hero.stashChargeState = stashChargeState
 end
 
 function LoadStashState(hero)
-    local stashState = hero.stashState
-    local stashChargeState = hero.stashChargeState
+    local stashState = hero.stashState or {}
+    local stashChargeState = hero.stashChargeState or {}
     -- fill inventory with dummy items so AddItem adds to correct index
     for i=0,5 do
         local item = hero:GetItemInSlot(i)

--- a/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
@@ -1563,3 +1563,53 @@ function RemoveHeroFromLinkTables(targethero)
         end
     end)]]
 end
+
+function SaveStashState(hero)
+    local stashState = {}
+    local stashChargeState = {}
+    for i=1, 6 do
+        local item = hero:GetItemInSlot(i + 5)
+        table.insert(stashState, i, item and item:GetName())
+        table.insert(stashChargeState, i, item and item:GetCurrentCharges())
+    end
+    for i=1,6 do
+        local m = (stashState[i] or "nil")
+        local m1 = (stashChargeState[i] or "nil")
+        print(m .. " " .. m1)
+    end
+    hero.stashState = stashState
+    hero.stashChargeState = stashChargeState
+end
+
+function LoadStashState(hero)
+    local stashState = hero.stashState
+    local stashChargeState = hero.stashChargeState
+    -- fill inventory with dummy items so AddItem adds to correct index
+    for i=0,5 do
+        local item = hero:GetItemInSlot(i)
+        if item == nil then
+            local dummyItem = CreateItem("item_dummy_item", nil, nil)
+            hero:AddItem(dummyItem)
+        end
+    end
+    for i=1,6 do
+        local item = hero:GetItemInSlot(i + 5)
+        hero:RemoveItem(item)
+
+        local savedItemName = stashState[i]
+        local newItem = CreateItem(savedItemName or "item_dummy_item", nil, nil)
+        hero:AddItem(newItem)
+
+        local charges = stashChargeState[i]
+        if charges ~= nil then
+            newItem:SetCurrentCharges(charges)
+        end
+    end
+    -- clear dummy items
+    for i=0,11 do
+        local item = hero:GetItemInSlot(i)
+        if item:GetName() == "item_dummy_item" then
+            hero:RemoveItem(item)
+        end
+    end
+end

--- a/game/dota_addons/fateanother/scripts/vscripts/master_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/master_ability.lua
@@ -914,6 +914,8 @@ function OnAMAcquired(keys)
 	hero:AddItem(CreateItem("item_shard_of_anti_magic" , nil, nil)) 
     local statTable = CreateTemporaryStatTable(hero)
     CustomGameEventManager:Send_ServerToPlayer( hero:GetPlayerOwner(), "servant_stats_updated", statTable ) -- Send the current stat info to JS
+
+    SaveStashState(hero)
 end
 
 function OnReplenishmentAcquired(keys)
@@ -929,6 +931,8 @@ function OnReplenishmentAcquired(keys)
 	hero:AddItem(CreateItem("item_shard_of_replenishment" , nil, nil)) 
     local statTable = CreateTemporaryStatTable(hero)
     CustomGameEventManager:Send_ServerToPlayer( hero:GetPlayerOwner(), "servant_stats_updated", statTable ) -- Send the current stat info to JS
+
+    SaveStashState(hero)
 end
 
 function OnProsperityAcquired(keys)


### PR DESCRIPTION
See #98.

### Important

- **Behavior change** You are now able to buy more than 10 C Scrolls in base. Gold will be deducted accordingly, and the purchase refunded if you do not have the gold. Should this be reverted so you can only buy 10 C Scrolls in base? Would the change be too unintuitive are used to the old way?
- **TODO** Update error messages for C Scroll out of stock
- **TODO** Refund item stock. Not sure how to do this currently.
- **TODO** Optimise - since the inventory sizes are fixed to 12, there should not be a performance problem. Optimisation is possible by doing more checks instead of recreating all the items.
- **Check** Check that all `AddItem` scenarios are covered (currently they are acquire Shard of Antimagic, acquire Shard of Replenishment and Item Construction)
- **Check** More rigorous checks should be done especially with multiple players instead of in a local lobby to see if edge cases have been covered.
