### PR TITLE
Combo indicator feature

### DIFF
--- a/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_config.js
+++ b/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_config.js
@@ -122,6 +122,16 @@ function UpdateMountStatus(data)
     $.Msg(bIsMounted);
 }
 
+function RegisterMasterUnit(data) {
+    var config = GameUI.CustomUIConfig()
+    if (!config.masterUnits) {
+        config.masterUnits = {}
+    }
+    var hero = data.hero;
+    var masterUnit = data.shardUnit;
+    config.masterUnits[hero] = masterUnit;
+}
+
 (function()
 {
     $("#FateConfigBoard").visible = false;
@@ -132,4 +142,5 @@ function UpdateMountStatus(data)
     GameEvents.Subscribe( "dota_player_update_selected_unit", CheckTransportSelection );
     GameEvents.Subscribe( "player_summoned_transport", RegisterTransport);
     GameEvents.Subscribe( "player_mount_status_changed", UpdateMountStatus);
+	GameEvents.Subscribe( "player_register_master_unit", RegisterMasterUnit);
 })();

--- a/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_config.js
+++ b/content/dota_addons/fateanother/panorama/scripts/custom_game/fateanother_config.js
@@ -124,12 +124,14 @@ function UpdateMountStatus(data)
 
 function RegisterMasterUnit(data) {
     var config = GameUI.CustomUIConfig()
-    if (!config.masterUnits) {
-        config.masterUnits = {}
-    }
     var hero = data.hero;
     var masterUnit = data.shardUnit;
     config.masterUnits[hero] = masterUnit;
+}
+
+function RegisterAllMasterUnits(data) {
+    var config = GameUI.CustomUIConfig()
+    config.masterUnits = data;
 }
 
 (function()
@@ -142,5 +144,12 @@ function RegisterMasterUnit(data) {
     GameEvents.Subscribe( "dota_player_update_selected_unit", CheckTransportSelection );
     GameEvents.Subscribe( "player_summoned_transport", RegisterTransport);
     GameEvents.Subscribe( "player_mount_status_changed", UpdateMountStatus);
-	GameEvents.Subscribe( "player_register_master_unit", RegisterMasterUnit);
+
+    var config = GameUI.CustomUIConfig()
+    if (!config.masterUnits) {
+        config.masterUnits = {}
+    }
+
+    GameEvents.Subscribe( "player_register_master_unit", RegisterMasterUnit);
+    GameEvents.Subscribe( "player_register_all_master_units", RegisterAllMasterUnits);
 })();

--- a/content/dota_addons/fateanother/panorama/scripts/custom_game/shared_scoreboard_updater.js
+++ b/content/dota_addons/fateanother/panorama/scripts/custom_game/shared_scoreboard_updater.js
@@ -601,7 +601,12 @@ Entities.HasModifier = function(entIndex, modifierName){
 	return false
 };
 
-function GetComboStatus(entIndex) {
+function GetComboStatus(heroEntIndex) {
+	var config = GameUI.CustomUIConfig();
+	var entIndex = config.masterUnits && config.masterUnits[heroEntIndex];
+	if (!entIndex) {
+		return -1
+	}
 	var nBuffs = Entities.GetNumBuffs(entIndex)
 	for (var i = 0; i < nBuffs; i++) {
 		var buff = Entities.GetBuff(entIndex, i);

--- a/content/dota_addons/fateanother/panorama/scripts/custom_game/shared_scoreboard_updater.js
+++ b/content/dota_addons/fateanother/panorama/scripts/custom_game/shared_scoreboard_updater.js
@@ -29,25 +29,41 @@ function _ScoreboardUpdater_UpdatePlayerPanel( scoreboardConfig, playersContaine
 		playerPanel.SetPanelEvent(
 			"onactivate",
 			function() {
-				if (!GameUI.IsAltDown()) {
-					Players.PlayerPortraitClicked(playerId, false, false);
-					return;
-				}
-				var playerInfo = Game.GetPlayerInfo(playerId);
-				var isDead = playerInfo.player_respawn_seconds >= 0;
-				var localPlayerId = Game.GetLocalPlayerID();
-				var message;
-				if (localPlayerId == playerId) {
-					message = "_gray__arrow_ _default_I am _gold_" + (isDead ? "dead" : "alive") + "_default_!";
-				} else {
-					var localPlayerInfo = Game.GetPlayerInfo(localPlayerId);
-					if (playerInfo.player_team_id != localPlayerInfo.player_team_id) {
-						var heroName = playerInfo.player_selected_hero
-						message = "_gray__arrow_ _default_Enemy _gold_" + heroName + "_default_ is " + (isDead ? "dead" : "missing") + "!";
+				if (GameUI.IsAltDown()) {
+					var playerInfo = Game.GetPlayerInfo(playerId);
+					var isDead = playerInfo.player_respawn_seconds >= 0;
+					var localPlayerId = Game.GetLocalPlayerID();
+					var message;
+					if (localPlayerId == playerId) {
+						message = "_gray__arrow_ _default_I am _gold_" + (isDead ? "dead" : "alive") + "_default_!";
+					} else {
+						var localPlayerInfo = Game.GetPlayerInfo(localPlayerId);
+						if (playerInfo.player_team_id != localPlayerInfo.player_team_id) {
+							var heroName = playerInfo.player_selected_hero
+							message = "_gray__arrow_ _default_Enemy _gold_" + heroName + "_default_ is " + (isDead ? "dead" : "missing") + "!";
+						}
 					}
-				}
-				if (message) {
+					if (message) {
+						GameEvents.SendCustomGameEventToServer("player_alt_click", {message: message});
+					}
+				} else if (GameUI.IsControlDown()) {
+					var localPlayerId = Game.GetLocalPlayerID();
+					if (localPlayerId != playerId) {
+						return;
+					}
+					var hero = Players.GetPlayerHeroEntityIndex(playerID);
+					var comboStatus = GetComboStatus(hero)
+					var message = "_gold_ Combo _gray__arrow_ _default_";
+					if (comboStatus == 0) {
+						message += "Ready"
+					} else if (comboStatus == -1) {
+						message += "Unavailable"
+					} else {
+						message += "On cooldown ( " + Math.ceil(comboStatus) + " seconds remain )"
+					}
 					GameEvents.SendCustomGameEventToServer("player_alt_click", {message: message});
+				} else {
+							Players.PlayerPortraitClicked(playerId, false, false);
 				}
 			}
 		);
@@ -232,11 +248,13 @@ function _ScoreboardUpdater_UpdatePlayerPanel( scoreboardConfig, playersContaine
 
 	_ScoreboardUpdater_SetTextSafe( playerPanel, "PlayerGoldAmount", goldValue );
 
-	playerPanel.SetHasClass( "player_ultimate_ready", ( ultStateOrTime == PlayerUltimateStateOrTime_t.PLAYER_ULTIMATE_STATE_READY ) );
-	playerPanel.SetHasClass( "player_ultimate_no_mana", ( ultStateOrTime == PlayerUltimateStateOrTime_t.PLAYER_ULTIMATE_STATE_NO_MANA) );
-	playerPanel.SetHasClass( "player_ultimate_not_leveled", ( ultStateOrTime == PlayerUltimateStateOrTime_t.PLAYER_ULTIMATE_STATE_NOT_LEVELED) );
-	playerPanel.SetHasClass( "player_ultimate_hidden", ( ultStateOrTime == PlayerUltimateStateOrTime_t.PLAYER_ULTIMATE_STATE_HIDDEN) );
-	playerPanel.SetHasClass( "player_ultimate_cooldown", ( ultStateOrTime > 0 ) );
+	var hero = Players.GetPlayerHeroEntityIndex(playerID);
+	var comboStatus = GetComboStatus(hero)
+	playerPanel.SetHasClass( "player_ultimate_ready", comboStatus == 0);
+	// playerPanel.SetHasClass( "player_ultimate_no_mana", ( ultStateOrTime == PlayerUltimateStateOrTime_t.PLAYER_ULTIMATE_STATE_NO_MANA) );
+	playerPanel.SetHasClass( "player_ultimate_not_leveled", comboStatus == -1);
+	// playerPanel.SetHasClass( "player_ultimate_hidden", ( ultStateOrTime == PlayerUltimateStateOrTime_t.PLAYER_ULTIMATE_STATE_HIDDEN) );
+	playerPanel.SetHasClass( "player_ultimate_cooldown", comboStatus > 0);
 	_ScoreboardUpdater_SetTextSafe( playerPanel, "PlayerUltimateCooldown", ultStateOrTime );
 }
 
@@ -582,3 +600,18 @@ Entities.HasModifier = function(entIndex, modifierName){
 	};
 	return false
 };
+
+function GetComboStatus(entIndex) {
+	var nBuffs = Entities.GetNumBuffs(entIndex)
+	for (var i = 0; i < nBuffs; i++) {
+		var buff = Entities.GetBuff(entIndex, i);
+		var buffName = Buffs.GetName(entIndex, buff);
+		if (buffName == "combo_unavailable") {
+			return -1
+		}
+		if (buffName == "combo_cooldown") {
+			return Buffs.GetRemainingTime(entIndex, buff);
+		}
+	};
+	return 0;
+}

--- a/game/dota_addons/fateanother/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/fateanother/scripts/npc/npc_abilities_custom.txt
@@ -28494,6 +28494,20 @@
 					"MODIFIER_STATE_ROOTED"		"MODIFIER_STATE_VALUE_ENABLED"
 				}
 		  	}
+			"modifier_combo_checker"
+			{
+				"Passive"		"1"
+				"IsHidden"		"1"
+				"ThinkInterval"				"0.3"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+					 	"ScriptFile"	"master_ability"
+					 	"Function"		"OnComboCheck"
+					}
+				}
+			}
 		}
 	}
 	//================================================
@@ -28578,6 +28592,18 @@
 					}
 				}
 			}
+			"combo_unavailable"
+			{
+				"IsDebuff"		"1"
+				"IsHidden"		"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
+			}			
+			"combo_cooldown"
+			{
+				"IsDebuff"		"1"
+				"IsHidden"		"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
+			}			
 			"pause_sealenabled"
 			{
 				"IsDebuff"		"1"

--- a/game/dota_addons/fateanother/scripts/npc/npc_abilities_custom.txt
+++ b/game/dota_addons/fateanother/scripts/npc/npc_abilities_custom.txt
@@ -28508,6 +28508,18 @@
 					}
 				}
 			}
+			"combo_unavailable"
+			{
+				"IsDebuff"		"1"
+				"IsHidden"		"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
+			}
+			"combo_cooldown"
+			{
+				"IsDebuff"		"1"
+				"IsHidden"		"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
+			}
 		}
 	}
 	//================================================
@@ -28592,18 +28604,6 @@
 					}
 				}
 			}
-			"combo_unavailable"
-			{
-				"IsDebuff"		"1"
-				"IsHidden"		"1"
-				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
-			}			
-			"combo_cooldown"
-			{
-				"IsDebuff"		"1"
-				"IsHidden"		"1"
-				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE"
-			}			
 			"pause_sealenabled"
 			{
 				"IsDebuff"		"1"

--- a/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
@@ -1077,6 +1077,22 @@ function FateGameMode:OnPlayerReconnect(keys)
         }
         CustomGameEventManager:Send_ServerToPlayer( ply, "player_selected_hero", playerData )
         --CustomGameEventManager:Send_ServerToAllClients( "victory_condition_set", victoryConditionData ) -- Send the winner to Javascript
+
+        local masterUnits = {}
+        self:LoopOverPlayers(function(player, playerID, hero)
+            if hero == nil then
+              return
+            end
+            local masterUnit = hero.MasterUnit
+            if masterUnit == nil then
+              return
+            end
+
+            local masterEntIndex = masterUnit:entindex()
+            local heroEntIndex = hero:entindex()
+            masterUnits[heroEntIndex] = masterEntIndex
+        end)
+        CustomGameEventManager:Send_ServerToPlayer(ply, "player_register_all_master_units", masterUnits)
         return
     end)
 end

--- a/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/addon_game_mode.lua
@@ -907,9 +907,11 @@ function FateGameMode:OnHeroInGame(hero)
     LevelAllAbility(master2)
     local playerData = {
         masterUnit = master2:entindex(),
-        shardUnit = master:entindex()
+        shardUnit = master:entindex(),
+        hero = hero:entindex()
     }
-    CustomGameEventManager:Send_ServerToPlayer( hero:GetPlayerOwner(), "player_selected_hero", playerData )
+    CustomGameEventManager:Send_ServerToPlayer(hero:GetPlayerOwner(), "player_selected_hero", playerData)
+    CustomGameEventManager:Send_ServerToAllClients("player_register_master_unit", playerData)
     --[[-- Create personal stash for hero
     masterStash = CreateUnitByName("master_stash", Vector(4500 + hero:GetPlayerID()*350,-7250,0), true, hero, hero, hero:GetTeamNumber())
     masterStash:SetControllableByPlayer(hero:GetPlayerID(), true)

--- a/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/libraries/util.lua
@@ -1615,3 +1615,68 @@ end
 function FindName(name)
     return heroNames[name] or "Undefined"
 end
+
+local heroCombos = {
+    ["npc_dota_hero_legion_commander"] = "saber_max_excalibur",
+    ["npc_dota_hero_phantom_lancer"] = "lancer_5th_wesen_gae_bolg",
+    ["npc_dota_hero_spectre"] = "saber_alter_max_mana_burst",
+    ["npc_dota_hero_ember_spirit"] = "archer_5th_arrow_rain",
+    ["npc_dota_hero_templar_assassin"] = "rider_5th_bellerophon_2",
+    ["npc_dota_hero_doom_bringer"] = "berserker_5th_madmans_roar",
+    ["npc_dota_hero_juggernaut"] = "false_assassin_tsubame_mai",
+    ["npc_dota_hero_bounty_hunter"] = "true_assassin_combo",
+    ["npc_dota_hero_crystal_maiden"] = "caster_5th_hecatic_graea_powered",
+    ["npc_dota_hero_skywrath_mage"] = "gilgamesh_max_enuma_elish",
+    ["npc_dota_hero_sven"] = "lancelot_nuke",
+    ["npc_dota_hero_vengefulspirit"] = "avenger_endless_loop",
+    ["npc_dota_hero_huskar"] = "diarmuid_rampant_warrior",
+    ["npc_dota_hero_chen"] = "iskander_annihilate",
+    ["npc_dota_hero_shadow_shaman"] = "gille_larret_de_mort",
+    ["npc_dota_hero_lina"] = "nero_fiery_finale",
+    ["npc_dota_hero_omniknight"] = "gawain_supernova",
+    ["npc_dota_hero_enchantress"] = "tamamo_polygamist_castration_fist",
+    ["npc_dota_hero_bloodseeker"] = "lishuwen_raging_dragon_strike",
+    ["npc_dota_hero_mirana"] = "jeanne_combo_la_pucelle",
+    ["npc_dota_hero_queenofpain"] = "astolfo_hippogriff_ride",
+    ["npc_dota_hero_windrunner"] = "nursery_rhyme_story_for_somebodys_sake",
+}
+
+function GetHeroCombo(hero)
+    local name = hero:GetName()
+    return heroCombos[name] or ""
+end
+
+-- returns -1 if combo is not available
+-- returns 0 if combo is available and ready
+-- otherwise returns cooldown remaning on combo
+function GetComboAvailability(hero)
+    local heroName = hero:GetName()
+    if heroName == "npc_dota_hero_juggernaut" then
+        if hero:GetStrength() < 24.1 or hero:GetAgility() < 24.1 then
+            return -1
+        end
+    else
+        local statreq = 19.1
+        if heroName == "npc_dota_hero_sven" then
+            local ability = hero:FindAbilityByName("lancelot_arondite")
+            if hero:HasModifier("modifier_arondite") then
+                statreq = statreq + ability:GetLevelSpecialValueFor("bonus_allstat", ability:GetLevel() - 1)
+            end
+        end
+        if hero:GetStrength() < statreq
+            or hero:GetAgility() < statreq
+            or hero:GetIntellect() < statreq
+        then
+            return -1
+        end
+    end
+    local comboName = GetHeroCombo(hero)
+    if comboName == "" then
+        return -1
+    end
+    local combo = hero:FindAbilityByName(comboName)
+    if combo == nil then
+        return -1
+    end
+    return combo:GetCooldownTimeRemaining()
+end

--- a/game/dota_addons/fateanother/scripts/vscripts/master_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/master_ability.lua
@@ -1099,20 +1099,21 @@ end
 
 function OnComboCheck(keys)
 	local caster = keys.caster
+	local ability = keys.ability
 	local ply = caster:GetPlayerOwner()
 	local hero = ply:GetAssignedHero()
 
-	if hero:HasModifier("combo_cooldown") then
-		hero:RemoveModifierByName("combo_cooldown")
+	if caster:HasModifier("combo_cooldown") then
+		caster:RemoveModifierByName("combo_cooldown")
 	end
-	if hero:HasModifier("combo_unavailable") then
-		hero:RemoveModifierByName("combo_unavailable")
+	if caster:HasModifier("combo_unavailable") then
+		caster:RemoveModifierByName("combo_unavailable")
 	end
 
 	local comboAvailability = GetComboAvailability(hero)
 	if comboAvailability == -1 then
-		giveUnitDataDrivenModifier(hero, hero, "combo_unavailable", 1)
+		ability:ApplyDataDrivenModifier(caster, caster, "combo_unavailable", {duration=1})
 	elseif comboAvailability > 0 then
-		giveUnitDataDrivenModifier(hero, hero, "combo_cooldown", comboAvailability)
+		ability:ApplyDataDrivenModifier(caster, caster, "combo_cooldown", {duration=comboAvailability})
 	end
 end

--- a/game/dota_addons/fateanother/scripts/vscripts/master_ability.lua
+++ b/game/dota_addons/fateanother/scripts/vscripts/master_ability.lua
@@ -1096,3 +1096,23 @@ function OnHeroRespawn(keys)
 	end
 	FindClearSpaceForUnit( caster, caster:GetAbsOrigin(), true )
 end
+
+function OnComboCheck(keys)
+	local caster = keys.caster
+	local ply = caster:GetPlayerOwner()
+	local hero = ply:GetAssignedHero()
+
+	if hero:HasModifier("combo_cooldown") then
+		hero:RemoveModifierByName("combo_cooldown")
+	end
+	if hero:HasModifier("combo_unavailable") then
+		hero:RemoveModifierByName("combo_unavailable")
+	end
+
+	local comboAvailability = GetComboAvailability(hero)
+	if comboAvailability == -1 then
+		giveUnitDataDrivenModifier(hero, hero, "combo_unavailable", 1)
+	elseif comboAvailability > 0 then
+		giveUnitDataDrivenModifier(hero, hero, "combo_cooldown", comboAvailability)
+	end
+end


### PR DESCRIPTION
Updated the top panel UI so what used to be the ultimate indicator (shows if ultimate is available, ready, on cooldown or requires more mana) now shows the combo status. The different states are unavailable, ready and on cooldown (mana is not represented since most combos need another skill to activate so there is some data requried which Panorama might not be able to access).

Control click on the hero portrait will indicate the status of the combo.

I chose not to use the combo ability or already in place cooldown indicators as I wanted to do the combo available check, rather than just a cooldown check. Furthermore, there is an issue with checking modifiers or applying modifiers on dead units (not sure which and I feel like I might have done something wrong). Therefore I chose to apply the modifiers on the Master unit instead. Using `combo_unavailable` and `combo_cooldown` for all heroes makes it easier. 

Perhaps there is a better way which unifies with the current cooldown indicators.

- [x] Check Lancelot's and FA's combo requirement interactions
- [x] Check interaction with Gawain's Sunlight W
- [x] Check interactions with stat reduction or gain (Ruler's Q, TA's E)
----
- [x] Fix indicators disappearing if a player reconnects as the master unit table is lost
- [x] Check with multiple players